### PR TITLE
Fix README Docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ docker build -t telegram-bot .
 Run the container:
 
 ```sh
-docker run -e TELEGRAM_TOKEN=your_token -e OPENAI_API_KEY=your_api_key telegram-bot
+docker run -e TELEGRAM_TOKEN=your_token -e CHAT_ID=your_chat_id -e OPENAI_API_KEY=your_api_key telegram-bot
 ```
 
 


### PR DESCRIPTION
## Summary
- update README's Docker instructions to include CHAT_ID

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68741e1ee414832eaa2c5ce58e0f566f