### PR TITLE
Fix YAML in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,10 +57,10 @@ jobs:
             cd /opt/telegram-reminder/telegram-reminder
             # Обновляем .env
             cat > .env << ENV
-TELEGRAM_TOKEN=${{ secrets.TELEGRAM_TOKEN }}
-OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
-CHAT_ID=${{ secrets.CHAT_ID }}
-ENV
+            TELEGRAM_TOKEN=${{ secrets.TELEGRAM_TOKEN }}
+            OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
+            CHAT_ID=${{ secrets.CHAT_ID }}
+            ENV
 
             # Подтягиваем образ и перезапускаем
             docker pull ${{ secrets.DOCKERHUB_USER }}/telegram-reminder:latest


### PR DESCRIPTION
## Summary
- fix indentation for `.env` block in deploy workflow

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687421014a40832eae47e8c8d5b44092