### PR TITLE
Add context timeouts for OpenAI calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ go run main.go
 ```
 
 Once started, the scheduler will automatically send the two daily messages at the specified times.
+Each request to OpenAI uses a 40-second timeout to avoid hanging jobs.
 
 ## Deploying on a server
 


### PR DESCRIPTION
## Summary
- pass a context with timeout to OpenAI requests
- log timeout errors
- document the new timeout in the README

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687422141238832e99cd50635c000ca8