### PR TITLE
Add scheduler and OpenAI tests

### DIFF
--- a/completion_test.go
+++ b/completion_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	openai "github.com/sashabaranov/go-openai"
+)
+
+type mockAI struct {
+	received openai.ChatCompletionRequest
+	resp     openai.ChatCompletionResponse
+	err      error
+}
+
+func (m *mockAI) CreateChatCompletion(_ context.Context, req openai.ChatCompletionRequest) (openai.ChatCompletionResponse, error) {
+	m.received = req
+	return m.resp, m.err
+}
+
+func TestChatCompletionSuccess(t *testing.T) {
+	m := &mockAI{resp: openai.ChatCompletionResponse{Choices: []openai.ChatCompletionChoice{
+		{Message: openai.ChatCompletionMessage{Content: "  hi "}},
+	}}}
+	got, err := chatCompletion(m, "prompt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "hi" {
+		t.Errorf("got %q", got)
+	}
+	if m.received.Messages[0].Content != "prompt" {
+		t.Errorf("prompt not forwarded")
+	}
+}
+
+func TestChatCompletionNoChoices(t *testing.T) {
+	m := &mockAI{}
+	got, err := chatCompletion(m, "test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "" {
+		t.Errorf("expected empty, got %q", got)
+	}
+}
+
+func TestChatCompletionError(t *testing.T) {
+	m := &mockAI{err: errors.New("boom")}
+	_, err := chatCompletion(m, "test")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/completion_test.go
+++ b/completion_test.go
@@ -23,7 +23,7 @@ func TestChatCompletionSuccess(t *testing.T) {
 	m := &mockAI{resp: openai.ChatCompletionResponse{Choices: []openai.ChatCompletionChoice{
 		{Message: openai.ChatCompletionMessage{Content: "  hi "}},
 	}}}
-	got, err := chatCompletion(m, "prompt")
+	got, err := chatCompletion(context.Background(), m, "prompt")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -37,7 +37,7 @@ func TestChatCompletionSuccess(t *testing.T) {
 
 func TestChatCompletionNoChoices(t *testing.T) {
 	m := &mockAI{}
-	got, err := chatCompletion(m, "test")
+	got, err := chatCompletion(context.Background(), m, "test")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -48,7 +48,7 @@ func TestChatCompletionNoChoices(t *testing.T) {
 
 func TestChatCompletionError(t *testing.T) {
 	m := &mockAI{err: errors.New("boom")}
-	_, err := chatCompletion(m, "test")
+	_, err := chatCompletion(context.Background(), m, "test")
 	if err == nil {
 		t.Fatal("expected error")
 	}

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-co-op/gocron"
+	openai "github.com/sashabaranov/go-openai"
+)
+
+type fakeTime struct {
+	onNow func(*time.Location) time.Time
+}
+
+func (f fakeTime) Now(loc *time.Location) time.Time     { return f.onNow(loc) }
+func (f fakeTime) Unix(sec int64, nsec int64) time.Time { return time.Unix(sec, nsec) }
+func (f fakeTime) Sleep(d time.Duration)                { time.Sleep(d) }
+
+type noopAI struct{}
+
+func (noopAI) CreateChatCompletion(ctx context.Context, req openai.ChatCompletionRequest) (openai.ChatCompletionResponse, error) {
+	return openai.ChatCompletionResponse{}, nil
+}
+
+func TestSetupSchedulerTimes(t *testing.T) {
+	loc, _ := time.LoadLocation("Europe/Moscow")
+	s := gocron.NewScheduler(loc)
+	s.CustomTime(fakeTime{onNow: func(l *time.Location) time.Time {
+		return time.Date(2024, 1, 1, 12, 0, 0, 0, l)
+	}})
+
+	setupScheduler(s, noopAI{}, nil, 0)
+
+	s.StartAsync()
+	s.Stop()
+
+	times := []string{}
+	for _, job := range s.Jobs() {
+		times = append(times, job.NextRun().In(loc).Format("15:04"))
+	}
+	want := map[string]bool{"13:00": false, "20:00": false}
+	for _, tm := range times {
+		if _, ok := want[tm]; ok {
+			want[tm] = true
+		}
+	}
+	for tstr, ok := range want {
+		if !ok {
+			t.Fatalf("time %s not scheduled", tstr)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- refactor `chatCompletion` to accept an interface and add `setupScheduler`
- unit test chat completions via mocked OpenAI client
- verify scheduler jobs run at 13:00 and 20:00
- remove unnecessary sleep from scheduler test

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68742217fc64832ea3559a148d483249