### PR TITLE
Improve Docker setup and add env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+TELEGRAM_TOKEN=your_telegram_token
+CHAT_ID=123456789
+OPENAI_API_KEY=your_openai_key
+DOCKERHUB_USER=your_dockerhub_username

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 telegram-reminder
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN go build -o bot
 
 FROM alpine:latest
 WORKDIR /app
+RUN apk add --no-cache ca-certificates tzdata
 COPY --from=builder /app/bot ./bot
 CMD ["./bot"]
 

--- a/README.md
+++ b/README.md
@@ -52,4 +52,11 @@ Run the container:
 docker run -e TELEGRAM_TOKEN=your_token -e CHAT_ID=your_chat_id -e OPENAI_API_KEY=your_api_key telegram-bot
 ```
 
+You can also run the bot using `docker-compose`. Copy `.env.example` to `.env`, fill in the required values, then start the service:
+
+```sh
+cp .env.example .env
+docker-compose up -d
+```
+
 


### PR DESCRIPTION
## Summary
- create `.env.example` with required variables
- ignore `.env`
- install certificates & tzdata in Dockerfile
- document docker-compose in README

## Testing
- `go build ./...` *(fails: signal interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_687426240438832eb83056bf95b69e8a