### PR TITLE
Configure openai client timeout

### DIFF
--- a/completion_test.go
+++ b/completion_test.go
@@ -15,7 +15,9 @@ func newTestClient(handler http.HandlerFunc) (*openai.Client, *httptest.Server) 
 	srv := httptest.NewServer(handler)
 	cfg := openai.DefaultConfig("test")
 	cfg.BaseURL = srv.URL + "/"
-	cfg.HTTPClient = srv.Client()
+	c := srv.Client()
+	c.Timeout = openAITimeout
+	cfg.HTTPClient = c
 	return openai.NewClientWithConfig(cfg), srv
 }
 

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"strconv"
 	"strings"
@@ -33,6 +34,8 @@ const (
 Подавай одну бизнес‑идею + примерный план из 4‑5 пунктов (коротко) + ссылки на релевантные ресурсы/репо/доки. Стиль панибратский, минимум воды.
 `
 )
+
+const openAITimeout = 40 * time.Second
 
 var (
 	currentModel = "gpt-4o"
@@ -116,7 +119,9 @@ func main() {
 		log.Fatalf("failed to create bot: %v", err)
 	}
 
-	client := openai.NewClient(openaiKey)
+	cfg := openai.DefaultConfig(openaiKey)
+	cfg.HTTPClient = &http.Client{Timeout: openAITimeout}
+	client := openai.NewClientWithConfig(cfg)
 
 	moscowTZ, err := time.LoadLocation("Europe/Moscow")
 	if err != nil {


### PR DESCRIPTION
## Summary
- add `openAITimeout` constant
- configure `openai.NewClient` with an HTTP client using this timeout
- apply same timeout in unit test client helper

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687436525508832eab56030399220d0a