### PR TITLE
Fix secret expansion in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,10 +56,10 @@ jobs:
 
       - name: Deploy to VPS
         run: |
-          ssh -o StrictHostKeyChecking=no ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }} << 'EOF'
+          ssh -o StrictHostKeyChecking=no ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }} <<EOF
             cd /opt/telegram-reminder/telegram-reminder
             # Обновляем .env
-            cat > .env << ENV
+            cat > .env <<'ENV'
             TELEGRAM_TOKEN=${{ secrets.TELEGRAM_TOKEN }}
             OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
             CHAT_ID=${{ secrets.CHAT_ID }}


### PR DESCRIPTION
## Summary
- enable variable substitution when deploying via SSH
- protect ENV heredoc from remote expansion

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68743a59abcc832ead43f27aedcc9cb9