### PR TITLE
Enable multi-arch Docker build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,10 +40,19 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Build & Push image
-        run: |
-          docker build -t ${{ secrets.DOCKERHUB_USER }}/telegram-reminder:latest .
-          docker push ${{ secrets.DOCKERHUB_USER }}/telegram-reminder:latest
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USER }}/telegram-reminder:latest
+          platforms: linux/amd64,linux/arm64
 
   deploy:
     needs: build

--- a/README.md
+++ b/README.md
@@ -47,10 +47,18 @@ Before submitting a pull request, run `gofmt -w` to ensure all Go files are prop
 
 ## Docker
 
-Build the image:
+Build the image for the current platform:
 
 ```sh
 docker build -t telegram-bot .
+```
+
+To build and push a multi-platform image (linux/amd64 and linux/arm64) using
+`buildx`:
+
+```sh
+docker buildx build --platform linux/amd64,linux/arm64 \
+  -t your_dockerhub_user/telegram-bot:latest --push .
 ```
 
 Run the container:
@@ -69,11 +77,13 @@ docker-compose up -d
 ## GitHub Actions Deployment
 
 This repository includes a GitHub Actions workflow that automatically builds and
-deploys the Docker image on every push to the `main` branch. The workflow
-performs the following steps:
+deploys the Docker image on every push to the `main` branch. It uses Docker
+Buildx to create a multi-architecture image. The workflow performs the following
+steps:
 
 1. Check out the repository and compile the Go binary.
-2. Build and push the Docker image to Docker Hub.
+2. Use Docker Buildx to create and push a multi-platform image
+   (linux/amd64 and linux/arm64) to Docker Hub.
 3. Connect to the VPS via SSH and restart the container using
    `docker-compose`.
 


### PR DESCRIPTION
## Summary
- build Docker image for amd64+arm64 via buildx
- document how to build and push multi-arch images

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68743a5fe300832e81cb37ae4ad13379