### PR TITLE
Add context-aware completion and interface

### DIFF
--- a/completion_test.go
+++ b/completion_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -34,7 +35,7 @@ func TestChatCompletionSuccess(t *testing.T) {
 	defer srv.Close()
 
 	msg := openai.ChatCompletionMessage{Role: openai.ChatMessageRoleUser, Content: "prompt"}
-	got, err := chatCompletion(client, []openai.ChatCompletionMessage{msg})
+	got, err := chatCompletion(context.Background(), client, []openai.ChatCompletionMessage{msg})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -52,7 +53,7 @@ func TestChatCompletionNoChoices(t *testing.T) {
 	})
 	defer srv.Close()
 
-	got, err := chatCompletion(client, []openai.ChatCompletionMessage{{Role: openai.ChatMessageRoleUser, Content: "test"}})
+	got, err := chatCompletion(context.Background(), client, []openai.ChatCompletionMessage{{Role: openai.ChatMessageRoleUser, Content: "test"}})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -68,7 +69,7 @@ func TestChatCompletionError(t *testing.T) {
 	})}
 	client := openai.NewClientWithConfig(cfg)
 
-	_, err := chatCompletion(client, []openai.ChatCompletionMessage{{Role: openai.ChatMessageRoleUser, Content: "test"}})
+	_, err := chatCompletion(context.Background(), client, []openai.ChatCompletionMessage{{Role: openai.ChatMessageRoleUser, Content: "test"}})
 	if err == nil {
 		t.Fatal("expected error")
 	}


### PR DESCRIPTION
## Summary
- abstract chat completion via `ChatCompleter` interface
- allow passing context to `chatCompletion`
- apply timeouts when running scheduled jobs and `/chat` handler
- update completion tests

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68743a4ffe0c832e9e36241e588ffd07