### PR TITLE
Add golangci-lint to CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,6 +19,7 @@ jobs:
 
       - run: go vet ./...
 
+
       - name: Auto format with gofmt
         run: |
           gofmt -w -s $(git ls-files '*.go')
@@ -33,6 +34,13 @@ jobs:
             git commit -m "style: auto-format via gofmt"
             git push
           fi
+
+      - name: Install golangci-lint
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
+            | sh -s -- -b $(go env GOPATH)/bin v1.57.2
+
+      - run: golangci-lint run
 
       - run: go build ./...
       - run: go test ./...

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ go run main.go
 
 Once started, the scheduler will automatically send the two daily messages at the specified times.
 Each request to OpenAI uses a 40-second timeout to avoid hanging jobs.
-Before submitting a pull request, run `gofmt -w` to ensure all Go files are properly formatted.
+Before submitting a pull request, run `gofmt -w` and `golangci-lint run` to ensure formatting and pass all linters.
 
 ## Deploying on a server
 

--- a/completion_test.go
+++ b/completion_test.go
@@ -27,9 +27,11 @@ func TestChatCompletionSuccess(t *testing.T) {
 		if err := json.NewDecoder(r.Body).Decode(&received); err != nil {
 			t.Fatalf("decode: %v", err)
 		}
-		json.NewEncoder(w).Encode(openai.ChatCompletionResponse{Choices: []openai.ChatCompletionChoice{
+		if err := json.NewEncoder(w).Encode(openai.ChatCompletionResponse{Choices: []openai.ChatCompletionChoice{
 			{Message: openai.ChatCompletionMessage{Content: "  hi "}},
-		}})
+		}}); err != nil {
+			t.Fatalf("encode: %v", err)
+		}
 	})
 	defer srv.Close()
 
@@ -48,7 +50,9 @@ func TestChatCompletionSuccess(t *testing.T) {
 
 func TestChatCompletionNoChoices(t *testing.T) {
 	client, srv := newTestClient(func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(openai.ChatCompletionResponse{})
+		if err := json.NewEncoder(w).Encode(openai.ChatCompletionResponse{}); err != nil {
+			t.Fatalf("encode: %v", err)
+		}
 	})
 	defer srv.Close()
 

--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ func userCompletion(client *openai.Client, message string) (string, error) {
 }
 
 func scheduleDailyMessages(s *gocron.Scheduler, client *openai.Client, bot *tb.Bot, chatID int64) {
-	s.Every(1).Day().At("13:00").Do(func() {
+	if _, err := s.Every(1).Day().At("13:00").Do(func() {
 		text, err := systemCompletion(client, lunchIdeaPrompt)
 		if err != nil {
 			log.Printf("openai error: %v", err)
@@ -83,9 +83,11 @@ func scheduleDailyMessages(s *gocron.Scheduler, client *openai.Client, bot *tb.B
 		if _, err := bot.Send(tb.ChatID(chatID), text); err != nil {
 			log.Printf("telegram send error: %v", err)
 		}
-	})
+	}); err != nil {
+		log.Printf("schedule lunch job: %v", err)
+	}
 
-	s.Every(1).Day().At("20:00").Do(func() {
+	if _, err := s.Every(1).Day().At("20:00").Do(func() {
 		text, err := systemCompletion(client, dailyBriefPrompt)
 		if err != nil {
 			log.Printf("openai error: %v", err)
@@ -94,7 +96,9 @@ func scheduleDailyMessages(s *gocron.Scheduler, client *openai.Client, bot *tb.B
 		if _, err := bot.Send(tb.ChatID(chatID), text); err != nil {
 			log.Printf("telegram send error: %v", err)
 		}
-	})
+	}); err != nil {
+		log.Printf("schedule brief job: %v", err)
+	}
 }
 
 func main() {


### PR DESCRIPTION
## Summary
- add `golangci-lint` installation and run to Go workflow
- check linter errors via CI
- update README with new lint instructions
- fix errcheck lints in code

## Testing
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68743ab12bcc832ea0fbe1795cfb2283