### PR TITLE
Fix deploy workflow YAML indentation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,12 +68,12 @@ jobs:
           ssh -o StrictHostKeyChecking=no ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }} <<'EOF'
             cd /opt/telegram-reminder/telegram-reminder
             # Обновляем .env
-cat > .env <<'ENV'
-TELEGRAM_TOKEN=${{ secrets.TELEGRAM_TOKEN }}
-OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
-CHAT_ID=${{ secrets.CHAT_ID }}
-DOCKERHUB_USER=${{ secrets.DOCKERHUB_USER }}
-ENV
+            cat > .env <<'ENV'
+            TELEGRAM_TOKEN=${{ secrets.TELEGRAM_TOKEN }}
+            OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
+            CHAT_ID=${{ secrets.CHAT_ID }}
+            DOCKERHUB_USER=${{ secrets.DOCKERHUB_USER }}
+            ENV
 
             # Подтягиваем образ и перезапускаем
             docker pull ${{ secrets.DOCKERHUB_USER }}/telegram-reminder:latest


### PR DESCRIPTION
## Summary
- correct indentation for `.env` setup in `deploy.yml`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68743e04d514832e9adcc00af7f6f03b