### PR TITLE
Fix golangci-lint install method

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,6 +17,9 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Install golangci-lint
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.57.2
+
       - run: go vet ./...
 
       - name: Auto format with gofmt

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ go run main.go
 
 Once started, the scheduler will automatically send the two daily messages at the specified times.
 Each request to OpenAI uses a 40-second timeout to avoid hanging jobs.
-Before submitting a pull request, run `gofmt -w` to ensure all Go files are properly formatted.
+Before submitting a pull request, run `gofmt -w` to ensure all Go files are properly formatted. Install the linter with `go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.57.2` and then run `golangci-lint run`.
 
 ## Deploying on a server
 


### PR DESCRIPTION
## Summary
- install golangci-lint using `go install` in the CI workflow
- document golangci-lint installation in the README

## Testing
- `gofmt -w -s $(git ls-files '*.go')`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68743d802984832e956a32dd619f0b52