### PR TITLE
Notify chat on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ go run main.go
 ```
 
 Once started, the scheduler will automatically send the two daily messages at the specified times.
+On startup the bot also posts "джарвис в сети, обновление произошло успешно" to confirm a successful deployment.
 Each request to OpenAI uses a 40-second timeout to avoid hanging jobs.
 Before submitting a pull request, run `gofmt -w` to ensure all Go files are properly formatted.
 

--- a/startup_test.go
+++ b/startup_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"testing"
+
+	tb "gopkg.in/telebot.v3"
+)
+
+type fakeBot struct {
+	recipient tb.Recipient
+	message   interface{}
+	called    bool
+}
+
+func (f *fakeBot) Send(recipient tb.Recipient, what interface{}, opts ...interface{}) (*tb.Message, error) {
+	f.recipient = recipient
+	f.message = what
+	f.called = true
+	return nil, nil
+}
+
+func TestSendStartupMessage(t *testing.T) {
+	fb := &fakeBot{}
+	sendStartupMessage(fb, 42)
+	if !fb.called {
+		t.Fatal("send not called")
+	}
+	if id, ok := fb.recipient.(tb.ChatID); !ok || int64(id) != 42 {
+		t.Errorf("wrong recipient: %v", fb.recipient)
+	}
+	if fb.message != startupMessage {
+		t.Errorf("unexpected message: %v", fb.message)
+	}
+}


### PR DESCRIPTION
## Summary
- send a startup message to confirm deployment
- document the new behaviour
- test `sendStartupMessage`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68743f4c4288832e8bccdd068849ea9b