### PR TITLE
Add loadConfig helper

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
+// loadConfig reads environment variables and validates them.
+// TELEGRAM_TOKEN, CHAT_ID and OPENAI_API_KEY are required.
+// OPENAI_MODEL is optional.
+func loadConfig() (telegramToken string, chatID int64, openaiKey string, openaiModel string, err error) {
+	telegramToken = os.Getenv("TELEGRAM_TOKEN")
+	chatIDStr := os.Getenv("CHAT_ID")
+	openaiKey = os.Getenv("OPENAI_API_KEY")
+	openaiModel = os.Getenv("OPENAI_MODEL")
+
+	if telegramToken == "" || chatIDStr == "" || openaiKey == "" {
+		err = fmt.Errorf("missing required env vars")
+		return
+	}
+
+	chatID, err = strconv.ParseInt(chatIDStr, 10, 64)
+	if err != nil {
+		err = fmt.Errorf("invalid CHAT_ID: %w", err)
+		return
+	}
+
+	return
+}

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,40 @@
+package main
+
+import "testing"
+
+func TestLoadConfigSuccess(t *testing.T) {
+	t.Setenv("TELEGRAM_TOKEN", "token")
+	t.Setenv("CHAT_ID", "99")
+	t.Setenv("OPENAI_API_KEY", "key")
+	t.Setenv("OPENAI_MODEL", "model")
+
+	tok, chatID, key, model, err := loadConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tok != "token" || chatID != 99 || key != "key" || model != "model" {
+		t.Fatalf("unexpected values: %v %v %v %v", tok, chatID, key, model)
+	}
+}
+
+func TestLoadConfigMissing(t *testing.T) {
+	t.Setenv("TELEGRAM_TOKEN", "")
+	t.Setenv("CHAT_ID", "99")
+	t.Setenv("OPENAI_API_KEY", "key")
+
+	_, _, _, _, err := loadConfig()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestLoadConfigBadChatID(t *testing.T) {
+	t.Setenv("TELEGRAM_TOKEN", "token")
+	t.Setenv("CHAT_ID", "bad")
+	t.Setenv("OPENAI_API_KEY", "key")
+
+	_, _, _, _, err := loadConfig()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"os"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -109,20 +107,13 @@ func scheduleDailyMessages(s *gocron.Scheduler, client ChatCompleter, bot *tb.Bo
 }
 
 func main() {
-	telegramToken := os.Getenv("TELEGRAM_TOKEN")
-	chatIDStr := os.Getenv("CHAT_ID")
-	openaiKey := os.Getenv("OPENAI_API_KEY")
-	if telegramToken == "" || chatIDStr == "" || openaiKey == "" {
-		log.Fatal("Set TELEGRAM_TOKEN, CHAT_ID, OPENAI_API_KEY env vars")
-	}
-
-	if envModel := os.Getenv("OPENAI_MODEL"); envModel != "" {
-		currentModel = envModel
-	}
-
-	chatID, err := strconv.ParseInt(chatIDStr, 10, 64)
+	telegramToken, chatID, openaiKey, openaiModel, err := loadConfig()
 	if err != nil {
-		log.Fatalf("invalid CHAT_ID: %v", err)
+		log.Fatal(err)
+	}
+
+	if openaiModel != "" {
+		currentModel = openaiModel
 	}
 
 	bot, err := tb.NewBot(tb.Settings{Token: telegramToken})


### PR DESCRIPTION
## Summary
- centralize environment variable logic in `loadConfig`
- use `loadConfig` from `main`
- add unit tests for configuration loader

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68743f548748832ea1ff21614a5f9e19