### PR TITLE
Fix .env block delimiter

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,12 +71,12 @@ jobs:
             cd /opt/telegram-reminder/telegram-reminder
 
             echo "[📦] Обновляем .env..."
-            cat > .env <<EOT
+            cat <<EOF2 > .env
               TELEGRAM_TOKEN=${{ secrets.TELEGRAM_TOKEN }}
               OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
               CHAT_ID=${{ secrets.CHAT_ID }}
               DOCKERHUB_USER=${{ secrets.DOCKERHUB_USER }}
-            EOT
+            EOF2
 
             echo "[🔍] Проверяем docker-compose.yml..."
             if [ ! -f docker-compose.yml ]; then


### PR DESCRIPTION
## Summary
- adjust `.env` heredoc delimiter to use `EOF2` in deploy workflow

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68744994cd44832eb67b1c7d3523800e