### PR TITLE
Register bot commands at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ The bot can be deployed on any always‑online environment such as Railway, Fly.
 - `/lunch` – immediately request a lunch idea digest.
 - `/brief` – immediately request the daily brief.
 
+The bot registers these commands with Telegram on startup, so they appear in the
+client's command list automatically.
+
 The `/model` command controls which OpenAI model the bot uses for replies. When
 called without arguments it prints the currently selected model and lists a few
 supported options (`gpt-4o`, `gpt-4-turbo`, `gpt-3.5-turbo`). To switch the

--- a/main.go
+++ b/main.go
@@ -151,11 +151,23 @@ func main() {
 		currentModel = cfg.OpenAIModel
 	}
 
-	bot, err := tb.NewBot(tb.Settings{Token: cfg.TelegramToken})
-	if err != nil {
-		log.Fatalf("failed to create bot: %v", err)
-	}
-	log.Printf("Authorized as %s", bot.Me.Username)
+       bot, err := tb.NewBot(tb.Settings{Token: cfg.TelegramToken})
+       if err != nil {
+               log.Fatalf("failed to create bot: %v", err)
+       }
+       log.Printf("Authorized as %s", bot.Me.Username)
+
+       // Register bot commands so that they show up in Telegram's UI.
+       commands := []tb.Command{
+               {Text: "chat", Description: "ask the bot any question"},
+               {Text: "ping", Description: "health check"},
+               {Text: "model", Description: "show or change OpenAI model"},
+               {Text: "lunch", Description: "request a lunch idea"},
+               {Text: "brief", Description: "request the daily brief"},
+       }
+       if err := bot.SetCommands(commands); err != nil {
+               log.Printf("set commands: %v", err)
+       }
 
 	oaCfg := openai.DefaultConfig(cfg.OpenAIKey)
 	oaCfg.HTTPClient = &http.Client{Timeout: openAITimeout}


### PR DESCRIPTION
## Summary
- register Telegram commands with `bot.SetCommands`
- note auto registration in README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6874664d0e28832eb93ef1526a046415