### PR TITLE
Add whitelist with /start command

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,9 @@
 TELEGRAM_TOKEN=your_telegram_token
-CHAT_ID=123456789
+CHAT_ID=
 OPENAI_API_KEY=your_openai_key
 OPENAI_MODEL=
 LUNCH_TIME=13:00
 BRIEF_TIME=20:00
 TASKS_FILE=tasks.yml
+WHITELIST_FILE=whitelist.json
 DOCKERHUB_USER=your_dockerhub_username

--- a/config_test.go
+++ b/config_test.go
@@ -23,7 +23,6 @@ func TestLoadConfigSuccess(t *testing.T) {
 
 func TestLoadConfigMissing(t *testing.T) {
 	t.Setenv("TELEGRAM_TOKEN", "")
-	t.Setenv("CHAT_ID", "99")
 	t.Setenv("OPENAI_API_KEY", "key")
 
 	_, err := config.Load()
@@ -40,5 +39,19 @@ func TestLoadConfigBadChatID(t *testing.T) {
 	_, err := config.Load()
 	if err == nil {
 		t.Fatal("expected error")
+	}
+}
+
+func TestLoadConfigNoChatID(t *testing.T) {
+	t.Setenv("TELEGRAM_TOKEN", "token")
+	t.Setenv("CHAT_ID", "")
+	t.Setenv("OPENAI_API_KEY", "key")
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.ChatID != 0 {
+		t.Fatalf("unexpected chat id: %d", cfg.ChatID)
 	}
 }

--- a/internal/bot/whitelist.go
+++ b/internal/bot/whitelist.go
@@ -1,0 +1,91 @@
+package bot
+
+import (
+	"encoding/json"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+var whitelistFile = envDefault("WHITELIST_FILE", "whitelist.json")
+var wlMu sync.Mutex
+
+func loadWhitelist() ([]int64, error) {
+	wlMu.Lock()
+	defer wlMu.Unlock()
+
+	data, err := os.ReadFile(whitelistFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []int64{}, nil
+		}
+		return nil, err
+	}
+	var ids []int64
+	if len(data) == 0 {
+		return []int64{}, nil
+	}
+	if err := json.Unmarshal(data, &ids); err != nil {
+		return nil, err
+	}
+	return ids, nil
+}
+
+func saveWhitelist(ids []int64) error {
+	wlMu.Lock()
+	defer wlMu.Unlock()
+
+	data, err := json.Marshal(ids)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(whitelistFile, data, 0644)
+}
+
+// LoadWhitelist returns the list of whitelisted chat IDs.
+func LoadWhitelist() ([]int64, error) {
+	return loadWhitelist()
+}
+
+// AddIDToWhitelist stores the chat ID if it is not already present.
+func AddIDToWhitelist(id int64) error {
+	ids, err := loadWhitelist()
+	if err != nil {
+		return err
+	}
+	for _, v := range ids {
+		if v == id {
+			return nil
+		}
+	}
+	ids = append(ids, id)
+	return saveWhitelist(ids)
+}
+
+// RemoveIDFromWhitelist removes the chat ID from the list.
+func RemoveIDFromWhitelist(id int64) error {
+	ids, err := loadWhitelist()
+	if err != nil {
+		return err
+	}
+	out := ids[:0]
+	for _, v := range ids {
+		if v != id {
+			out = append(out, v)
+		}
+	}
+	return saveWhitelist(out)
+}
+
+// FormatWhitelist returns the IDs as a newline separated string.
+func FormatWhitelist(ids []int64) string {
+	if len(ids) == 0 {
+		return ""
+	}
+	strs := make([]string, len(ids))
+	for i, v := range ids {
+		strs[i] = strconv.FormatInt(v, 10)
+	}
+	return strings.Join(strs, "\n")
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,13 +23,17 @@ func Load() (Config, error) {
 	openaiKey := os.Getenv("OPENAI_API_KEY")
 	openaiModel := os.Getenv("OPENAI_MODEL")
 
-	if telegramToken == "" || chatIDStr == "" || openaiKey == "" {
+	if telegramToken == "" || openaiKey == "" {
 		return cfg, fmt.Errorf("missing required env vars")
 	}
 
-	chatID, err := strconv.ParseInt(chatIDStr, 10, 64)
-	if err != nil {
-		return cfg, fmt.Errorf("invalid CHAT_ID: %w", err)
+	var chatID int64
+	if chatIDStr != "" {
+		var err error
+		chatID, err = strconv.ParseInt(chatIDStr, 10, 64)
+		if err != nil {
+			return cfg, fmt.Errorf("invalid CHAT_ID: %w", err)
+		}
 	}
 
 	cfg = Config{


### PR DESCRIPTION
## Summary
- store chat IDs in a whitelist file
- register `/start`, `/whitelist` and `/remove` handlers
- send scheduled messages to all whitelisted chats
- make `CHAT_ID` optional and update tests
- document new behaviour and env vars

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687519172d0c832e8d48c1cc73e0a3cb