### PR TITLE
Fix runtime image missing tasks.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 FROM gcr.io/distroless/static
 WORKDIR /app
 COPY --from=builder /bot /app/bot
+COPY --from=builder /app/tasks.yml /app/tasks.yml
 USER nonroot:nonroot
 ENTRYPOINT ["/app/bot"]
 


### PR DESCRIPTION
## Summary
- include `tasks.yml` in runtime stage so the bot can load tasks

## Testing
- `go test ./...`
- *Docker not available: `docker build` failed*

------
https://chatgpt.com/codex/tasks/task_e_6875453cce9c832e91a430ba860321d3