### PR TITLE
Refactor config env constants

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -7,11 +7,11 @@ import (
 )
 
 func TestLoadConfigSuccess(t *testing.T) {
-	t.Setenv("TELEGRAM_TOKEN", "token")
-	t.Setenv("CHAT_ID", "99")
-	t.Setenv("OPENAI_API_KEY", "key")
-	t.Setenv("OPENAI_MODEL", "model")
-	t.Setenv("BLOCKCHAIN_API", "http://example.com")
+	t.Setenv(config.EnvTelegramToken, "token")
+	t.Setenv(config.EnvChatID, "99")
+	t.Setenv(config.EnvOpenAIKey, "key")
+	t.Setenv(config.EnvOpenAIModel, "model")
+	t.Setenv(config.EnvBlockchainAPI, "http://example.com")
 
 	cfg, err := config.Load()
 	if err != nil {
@@ -23,8 +23,8 @@ func TestLoadConfigSuccess(t *testing.T) {
 }
 
 func TestLoadConfigMissing(t *testing.T) {
-	t.Setenv("TELEGRAM_TOKEN", "")
-	t.Setenv("OPENAI_API_KEY", "key")
+	t.Setenv(config.EnvTelegramToken, "")
+	t.Setenv(config.EnvOpenAIKey, "key")
 
 	_, err := config.Load()
 	if err == nil {
@@ -33,9 +33,9 @@ func TestLoadConfigMissing(t *testing.T) {
 }
 
 func TestLoadConfigBadChatID(t *testing.T) {
-	t.Setenv("TELEGRAM_TOKEN", "token")
-	t.Setenv("CHAT_ID", "bad")
-	t.Setenv("OPENAI_API_KEY", "key")
+	t.Setenv(config.EnvTelegramToken, "token")
+	t.Setenv(config.EnvChatID, "bad")
+	t.Setenv(config.EnvOpenAIKey, "key")
 
 	_, err := config.Load()
 	if err == nil {
@@ -44,9 +44,9 @@ func TestLoadConfigBadChatID(t *testing.T) {
 }
 
 func TestLoadConfigNoChatID(t *testing.T) {
-	t.Setenv("TELEGRAM_TOKEN", "token")
-	t.Setenv("CHAT_ID", "")
-	t.Setenv("OPENAI_API_KEY", "key")
+	t.Setenv(config.EnvTelegramToken, "token")
+	t.Setenv(config.EnvChatID, "")
+	t.Setenv(config.EnvOpenAIKey, "key")
 
 	cfg, err := config.Load()
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,15 @@ import (
 	"strconv"
 )
 
+// Environment variable names
+const (
+	EnvTelegramToken = "TELEGRAM_TOKEN"
+	EnvChatID        = "CHAT_ID"
+	EnvOpenAIKey     = "OPENAI_API_KEY"
+	EnvOpenAIModel   = "OPENAI_MODEL"
+	EnvBlockchainAPI = "BLOCKCHAIN_API"
+)
+
 const DefaultBlockchainAPI = "https://api.blockchain.info/stats"
 
 // Config holds environment configuration values.
@@ -21,11 +30,11 @@ type Config struct {
 func Load() (Config, error) {
 	var cfg Config
 
-	telegramToken := os.Getenv("TELEGRAM_TOKEN")
-	chatIDStr := os.Getenv("CHAT_ID")
-	openaiKey := os.Getenv("OPENAI_API_KEY")
-	openaiModel := os.Getenv("OPENAI_MODEL")
-	blockchainAPI := os.Getenv("BLOCKCHAIN_API")
+	telegramToken := os.Getenv(EnvTelegramToken)
+	chatIDStr := os.Getenv(EnvChatID)
+	openaiKey := os.Getenv(EnvOpenAIKey)
+	openaiModel := os.Getenv(EnvOpenAIModel)
+	blockchainAPI := os.Getenv(EnvBlockchainAPI)
 
 	if telegramToken == "" || openaiKey == "" {
 		return cfg, fmt.Errorf("missing required env vars")


### PR DESCRIPTION
## Summary
- centralize environment variable names in config package
- update tests to use new constants

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687c1ce1278c832e901ee45f36f8e932