### PR TITLE
Simplify whitelist storage

### DIFF
--- a/internal/bot/whitelist.go
+++ b/internal/bot/whitelist.go
@@ -1,127 +1,64 @@
 package bot
 
 import (
-	"encoding/json"
-	"os"
 	"strconv"
 	"strings"
 	"sync"
 )
 
-// WhitelistFile is the path to the JSON file that stores chat IDs.
-// It can be overridden in tests.
-var WhitelistFile = envDefault("WHITELIST_FILE", "whitelist.json")
-var wlMu sync.Mutex
-
-// loadWhitelist reads the whitelist file and returns the list of chat IDs.
-// This is an internal function that handles the actual file I/O operations.
-// Returns an empty slice if the file doesn't exist.
-//
-// Returns:
-//   - []int64: Array of whitelisted chat IDs
-//   - error: Any error that occurred during file reading or parsing
-func loadWhitelist() ([]int64, error) {
-	wlMu.Lock()
-	defer wlMu.Unlock()
-
-	data, err := os.ReadFile(WhitelistFile)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return []int64{}, nil
-		}
-		return nil, err
-	}
-	var ids []int64
-	if len(data) == 0 {
-		return []int64{}, nil
-	}
-	if err := json.Unmarshal(data, &ids); err != nil {
-		return nil, err
-	}
-	return ids, nil
-}
-
-// saveWhitelist writes the list of chat IDs to the whitelist file.
-// This is an internal function that handles the actual file I/O operations.
-//
-// Parameters:
-//   - ids: Array of chat IDs to save
-//
-// Returns:
-//   - error: Any error that occurred during file writing
-func saveWhitelist(ids []int64) error {
-	wlMu.Lock()
-	defer wlMu.Unlock()
-
-	data, err := json.Marshal(ids)
-	if err != nil {
-		return err
-	}
-	return os.WriteFile(WhitelistFile, data, 0644)
-}
+var (
+	wlMu        sync.RWMutex
+	whitelistID []int64
+)
 
 // LoadWhitelist returns the list of whitelisted chat IDs.
-// This is the public interface for reading the whitelist.
-//
-// Returns:
-//   - []int64: Array of whitelisted chat IDs
-//   - error: Any error that occurred during loading
+// In-memory storage is used, so no errors are expected.
 func LoadWhitelist() ([]int64, error) {
-	return loadWhitelist()
+	wlMu.RLock()
+	ids := append([]int64(nil), whitelistID...)
+	wlMu.RUnlock()
+	return ids, nil
 }
 
 // AddIDToWhitelist stores the chat ID if it is not already present.
 // Duplicate IDs are ignored silently.
-//
-// Parameters:
-//   - id: Chat ID to add to the whitelist
-//
-// Returns:
-//   - error: Any error that occurred during the operation
 func AddIDToWhitelist(id int64) error {
-	ids, err := loadWhitelist()
-	if err != nil {
-		return err
-	}
-	for _, v := range ids {
+	wlMu.Lock()
+	for _, v := range whitelistID {
 		if v == id {
+			wlMu.Unlock()
 			return nil
 		}
 	}
-	ids = append(ids, id)
-	return saveWhitelist(ids)
+	whitelistID = append(whitelistID, id)
+	wlMu.Unlock()
+	return nil
 }
 
 // RemoveIDFromWhitelist removes the chat ID from the list.
 // If the ID is not present, the operation succeeds silently.
-//
-// Parameters:
-//   - id: Chat ID to remove from the whitelist
-//
-// Returns:
-//   - error: Any error that occurred during the operation
 func RemoveIDFromWhitelist(id int64) error {
-	ids, err := loadWhitelist()
-	if err != nil {
-		return err
-	}
-	out := ids[:0]
-	for _, v := range ids {
+	wlMu.Lock()
+	out := whitelistID[:0]
+	for _, v := range whitelistID {
 		if v != id {
 			out = append(out, v)
 		}
 	}
-	return saveWhitelist(out)
+	whitelistID = out
+	wlMu.Unlock()
+	return nil
+}
+
+// ResetWhitelist clears the in-memory list. Used in tests.
+func ResetWhitelist() {
+	wlMu.Lock()
+	whitelistID = nil
+	wlMu.Unlock()
 }
 
 // FormatWhitelist returns the IDs as a newline separated string.
 // Returns an empty string if the list is empty.
-//
-// Parameters:
-//   - ids: Array of chat IDs to format
-//
-// Returns:
-//   - string: Newline-separated list of chat IDs
 func FormatWhitelist(ids []int64) string {
 	if len(ids) == 0 {
 		return ""

--- a/whitelist_test.go
+++ b/whitelist_test.go
@@ -1,15 +1,13 @@
 package main
 
 import (
-	"path/filepath"
 	"testing"
 
 	botpkg "telegram-reminder/internal/bot"
 )
 
 func TestWhitelistAddRemove(t *testing.T) {
-	dir := t.TempDir()
-	botpkg.WhitelistFile = filepath.Join(dir, "wl.json")
+	botpkg.ResetWhitelist()
 
 	if err := botpkg.AddIDToWhitelist(10); err != nil {
 		t.Fatalf("add id: %v", err)


### PR DESCRIPTION
## Summary
- drop file-based whitelist and keep IDs in memory
- expose `ResetWhitelist` for tests
- update whitelist tests for new behaviour

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687d4bf2dc0c832e83cc06f6dcf809f7