### PR TITLE
Add dynamic command list for startup message

### DIFF
--- a/startup_test.go
+++ b/startup_test.go
@@ -15,7 +15,7 @@ func TestSendStartupMessage(t *testing.T) {
 	}
 
 	// Test with specific chat ID
-	bot.SendStartupMessage(b, 42)
+	bot.SendStartupMessage(b, 42, "test")
 
 	// The test passes if no error occurs
 	// In offline mode, the bot won't actually send messages


### PR DESCRIPTION
## Summary
- build commands list dynamically from task names
- refactor startup message to use new function

## Testing
- `go vet ./...`
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_687e91f24030832e9b1fb760559296df