### PR TITLE
Add Telegram debug logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ Dockerfile*
 
 # Tools
 /bot
+telegram-reminder

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@
 * Путь к файлу whitelist (`WHITELIST_FILE`, опционально, по умолчанию `whitelist.json`)
 * URL API блокчейна (`BLOCKCHAIN_API`, опционально, по умолчанию `https://api.blockchain.info/stats`)
 * Уровень логирования (`LOG_LEVEL`, опционально, `debug`, `info`, `warn` или `error`)
+* ID чата для логов (`LOG_CHAT_ID`, опционально)
 
 ## Добавление бота в каналы и группы
 
@@ -148,6 +149,7 @@ go run main.go
 
 - `TELEGRAM_TOKEN` – токен телеграм-бота
 - `CHAT_ID` – числовой ID чата назначения (опционально)
+- `LOG_CHAT_ID` – ID чата для отправки логов (опционально)
 - `OPENAI_API_KEY` – ключ API OpenAI
 - `OPENAI_MODEL` – имя модели OpenAI (опционально, по умолчанию `o3`)
 - `LUNCH_TIME` – время для идей на обед
@@ -168,6 +170,7 @@ BRIEF_TIME=18:00
 TASKS_FILE=tasks.yml
 WHITELIST_FILE=whitelist.json
 BLOCKCHAIN_API=https://api.blockchain.info/stats
+LOG_CHAT_ID=123456789
 ```
 
 ```yaml

--- a/config_test.go
+++ b/config_test.go
@@ -9,6 +9,7 @@ import (
 func TestLoadConfigSuccess(t *testing.T) {
 	t.Setenv(config.EnvTelegramToken, "token")
 	t.Setenv(config.EnvChatID, "99")
+	t.Setenv(config.EnvLogChatID, "100")
 	t.Setenv(config.EnvOpenAIKey, "key")
 	t.Setenv(config.EnvOpenAIModel, "model")
 	t.Setenv(config.EnvBlockchainAPI, "http://example.com")
@@ -17,7 +18,7 @@ func TestLoadConfigSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cfg.TelegramToken != "token" || cfg.ChatID != 99 || cfg.OpenAIKey != "key" || cfg.OpenAIModel != "model" || cfg.BlockchainAPI != "http://example.com" {
+	if cfg.TelegramToken != "token" || cfg.ChatID != 99 || cfg.LogChatID != 100 || cfg.OpenAIKey != "key" || cfg.OpenAIModel != "model" || cfg.BlockchainAPI != "http://example.com" {
 		t.Fatalf("unexpected values: %+v", cfg)
 	}
 }
@@ -35,6 +36,7 @@ func TestLoadConfigMissing(t *testing.T) {
 func TestLoadConfigBadChatID(t *testing.T) {
 	t.Setenv(config.EnvTelegramToken, "token")
 	t.Setenv(config.EnvChatID, "bad")
+	t.Setenv(config.EnvLogChatID, "101")
 	t.Setenv(config.EnvOpenAIKey, "key")
 
 	_, err := config.Load()
@@ -46,6 +48,7 @@ func TestLoadConfigBadChatID(t *testing.T) {
 func TestLoadConfigNoChatID(t *testing.T) {
 	t.Setenv(config.EnvTelegramToken, "token")
 	t.Setenv(config.EnvChatID, "")
+	t.Setenv(config.EnvLogChatID, "")
 	t.Setenv(config.EnvOpenAIKey, "key")
 
 	cfg, err := config.Load()
@@ -54,5 +57,17 @@ func TestLoadConfigNoChatID(t *testing.T) {
 	}
 	if cfg.ChatID != 0 {
 		t.Fatalf("unexpected chat id: %d", cfg.ChatID)
+	}
+}
+
+func TestLoadConfigBadLogChatID(t *testing.T) {
+	t.Setenv(config.EnvTelegramToken, "token")
+	t.Setenv(config.EnvChatID, "123")
+	t.Setenv(config.EnvLogChatID, "bad")
+	t.Setenv(config.EnvOpenAIKey, "key")
+
+	_, err := config.Load()
+	if err == nil {
+		t.Fatal("expected error")
 	}
 }

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"time"
 
+	"log/slog"
+
 	"telegram-reminder/internal/config"
 	"telegram-reminder/internal/logger"
 
@@ -617,6 +619,10 @@ func Run(cfg config.Config) error {
 		return fmt.Errorf("failed to create bot: %w", err)
 	}
 	log.Printf("Authorized as %s", b.Me.Username)
+
+	if cfg.LogChatID != 0 {
+		logger.EnableTelegramLogging(cfg.TelegramToken, cfg.LogChatID, slog.LevelDebug)
+	}
 
 	if cfg.ChatID != 0 {
 		if err := AddIDToWhitelist(cfg.ChatID); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 const (
 	EnvTelegramToken = "TELEGRAM_TOKEN"
 	EnvChatID        = "CHAT_ID"
+	EnvLogChatID     = "LOG_CHAT_ID"
 	EnvOpenAIKey     = "OPENAI_API_KEY"
 	EnvOpenAIModel   = "OPENAI_MODEL"
 	EnvBlockchainAPI = "BLOCKCHAIN_API"
@@ -21,6 +22,7 @@ const DefaultBlockchainAPI = "https://api.blockchain.info/stats"
 type Config struct {
 	TelegramToken string
 	ChatID        int64
+	LogChatID     int64
 	OpenAIKey     string
 	OpenAIModel   string
 	BlockchainAPI string
@@ -32,6 +34,7 @@ func Load() (Config, error) {
 
 	telegramToken := os.Getenv(EnvTelegramToken)
 	chatIDStr := os.Getenv(EnvChatID)
+	logChatIDStr := os.Getenv(EnvLogChatID)
 	openaiKey := os.Getenv(EnvOpenAIKey)
 	openaiModel := os.Getenv(EnvOpenAIModel)
 	blockchainAPI := os.Getenv(EnvBlockchainAPI)
@@ -49,6 +52,15 @@ func Load() (Config, error) {
 		}
 	}
 
+	var logChatID int64
+	if logChatIDStr != "" {
+		var err error
+		logChatID, err = strconv.ParseInt(logChatIDStr, 10, 64)
+		if err != nil {
+			return cfg, fmt.Errorf("invalid LOG_CHAT_ID: %w", err)
+		}
+	}
+
 	if blockchainAPI == "" {
 		blockchainAPI = DefaultBlockchainAPI
 	}
@@ -56,6 +68,7 @@ func Load() (Config, error) {
 	cfg = Config{
 		TelegramToken: telegramToken,
 		ChatID:        chatID,
+		LogChatID:     logChatID,
 		OpenAIKey:     openaiKey,
 		OpenAIModel:   openaiModel,
 		BlockchainAPI: blockchainAPI,

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -44,3 +44,11 @@ func parseLevel(l string) slog.Level {
 		return slog.LevelInfo
 	}
 }
+
+// EnableTelegramLogging adds a Telegram handler to the global logger.
+func EnableTelegramLogging(token string, chatID int64, level slog.Level) {
+	mu.Lock()
+	defer mu.Unlock()
+	th := NewTelegramHandler(token, chatID, level)
+	L = slog.New(newMulti(L.Handler(), th))
+}

--- a/internal/logger/multi.go
+++ b/internal/logger/multi.go
@@ -1,0 +1,50 @@
+package logger
+
+import (
+	"context"
+	"log/slog"
+)
+
+// multiHandler duplicates log records to multiple handlers.
+type multiHandler struct{ handlers []slog.Handler }
+
+func newMulti(hs ...slog.Handler) slog.Handler {
+	return &multiHandler{handlers: hs}
+}
+
+func (m *multiHandler) Enabled(ctx context.Context, l slog.Level) bool {
+	for _, h := range m.handlers {
+		if h.Enabled(ctx, l) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *multiHandler) Handle(ctx context.Context, r slog.Record) error {
+	var err error
+	for _, h := range m.handlers {
+		if h.Enabled(ctx, r.Level) {
+			if e := h.Handle(ctx, r); e != nil {
+				err = e
+			}
+		}
+	}
+	return err
+}
+
+func (m *multiHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	hs := make([]slog.Handler, len(m.handlers))
+	for i, h := range m.handlers {
+		hs[i] = h.WithAttrs(attrs)
+	}
+	return &multiHandler{handlers: hs}
+}
+
+func (m *multiHandler) WithGroup(name string) slog.Handler {
+	hs := make([]slog.Handler, len(m.handlers))
+	for i, h := range m.handlers {
+		hs[i] = h.WithGroup(name)
+	}
+	return &multiHandler{handlers: hs}
+}

--- a/internal/logger/telegram.go
+++ b/internal/logger/telegram.go
@@ -1,0 +1,50 @@
+package logger
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"log/slog"
+)
+
+// TelegramHandler sends logs to a Telegram chat.
+type TelegramHandler struct {
+	token  string
+	chatID int64
+	level  slog.Level
+}
+
+// NewTelegramHandler creates a handler that posts log messages to Telegram.
+func NewTelegramHandler(token string, chatID int64, level slog.Level) *TelegramHandler {
+	return &TelegramHandler{token: token, chatID: chatID, level: level}
+}
+
+func (h *TelegramHandler) Enabled(ctx context.Context, l slog.Level) bool {
+	return l >= h.level
+}
+
+func (h *TelegramHandler) Handle(ctx context.Context, r slog.Record) error {
+	var attrs []any
+	r.Attrs(func(a slog.Attr) bool {
+		attrs = append(attrs, a.Key, a.Value.Any())
+		return true
+	})
+	text := fmt.Sprintf("%s [%s] %s", r.Time.Format(time.RFC3339), r.Level.String(), r.Message)
+	if len(attrs) > 0 {
+		text += " " + fmt.Sprint(attrs...)
+	}
+	api := fmt.Sprintf("https://api.telegram.org/bot%s/sendMessage", h.token)
+	values := url.Values{
+		"chat_id": {strconv.FormatInt(h.chatID, 10)},
+		"text":    {text},
+	}
+	_, err := http.PostForm(api, values)
+	return err
+}
+
+func (h *TelegramHandler) WithAttrs(attrs []slog.Attr) slog.Handler { return h }
+func (h *TelegramHandler) WithGroup(name string) slog.Handler       { return h }


### PR DESCRIPTION
## Summary
- cleanup: drop binary and ignore it
- support LOG_CHAT_ID in config to send bot logs
- add Telegram log handler and hook it in bot
- document new variable
- cover new config logic with tests

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687e94558c74832e96759052f1a19b19