### PR TITLE
Implement web search and add tests

### DIFF
--- a/internal/bot/search.go
+++ b/internal/bot/search.go
@@ -1,0 +1,109 @@
+package bot
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// HTTPDoer defines minimal http client interface used by WebSearch.
+type HTTPDoer interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+// SearchHTTPClient is the HTTP client used for web search. It can be overridden in tests.
+var (
+	SearchHTTPClient HTTPDoer = http.DefaultClient
+	SearchBaseURL             = "https://duckduckgo.com/"
+)
+
+// SearchResult represents a single web search result.
+type SearchResult struct {
+	Title string
+	URL   string
+}
+
+// WebSearch performs a DuckDuckGo search and returns basic results.
+func WebSearch(ctx context.Context, query string) ([]SearchResult, error) {
+	if strings.TrimSpace(query) == "" {
+		return nil, nil
+	}
+	u, _ := url.Parse(SearchBaseURL)
+	q := u.Query()
+	q.Set("q", query)
+	q.Set("format", "json")
+	q.Set("no_redirect", "1")
+	q.Set("no_html", "1")
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := SearchHTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status %d", resp.StatusCode)
+	}
+
+	var data struct {
+		RelatedTopics []struct {
+			Text     string `json:"Text"`
+			FirstURL string `json:"FirstURL"`
+			Topics   []struct {
+				Text     string `json:"Text"`
+				FirstURL string `json:"FirstURL"`
+			} `json:"Topics"`
+		} `json:"RelatedTopics"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, err
+	}
+
+	var results []SearchResult
+	for _, t := range data.RelatedTopics {
+		if t.Text != "" && t.FirstURL != "" {
+			results = append(results, SearchResult{Title: t.Text, URL: t.FirstURL})
+		}
+		for _, sub := range t.Topics {
+			if sub.Text != "" && sub.FirstURL != "" {
+				results = append(results, SearchResult{Title: sub.Text, URL: sub.FirstURL})
+			}
+		}
+	}
+	return results, nil
+}
+
+// ExtractSearchQueries parses the prompt and returns search queries listed after the
+// "ВЕБ-ПОИСК" section.
+func ExtractSearchQueries(prompt string) []string {
+	var queries []string
+	lines := strings.Split(prompt, "\n")
+	inBlock := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.Contains(trimmed, "ВЕБ-ПОИСК") {
+			inBlock = true
+			continue
+		}
+		if inBlock {
+			if strings.HasPrefix(trimmed, "-") {
+				q := strings.TrimSpace(strings.TrimPrefix(trimmed, "-"))
+				q = strings.Trim(q, "\"")
+				if q != "" {
+					queries = append(queries, q)
+				}
+			} else if trimmed == "" || !strings.HasPrefix(trimmed, "-") {
+				break
+			}
+		}
+	}
+	return queries
+}

--- a/web_search_test.go
+++ b/web_search_test.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	botpkg "telegram-reminder/internal/bot"
+
+	openai "github.com/sashabaranov/go-openai"
+)
+
+// helper to create openai client backed by test server
+func newOAITestClient(handler http.HandlerFunc) (*openai.Client, *httptest.Server) {
+	srv := httptest.NewServer(handler)
+	cfg := openai.DefaultConfig("test")
+	cfg.BaseURL = srv.URL + "/"
+	c := srv.Client()
+	cfg.HTTPClient = c
+	return openai.NewClientWithConfig(cfg), srv
+}
+
+func TestExtractSearchQueries(t *testing.T) {
+	prompt := "intro\n🔍 ВЕБ-ПОИСК: Найди новости\n- \"query one\"\n- \"query two\"\nПОЛЕЗНЫЕ ССЫЛКИ:"
+	got := botpkg.ExtractSearchQueries(prompt)
+	if len(got) != 2 || got[0] != "query one" || got[1] != "query two" {
+		t.Fatalf("unexpected queries: %v", got)
+	}
+
+	if q := botpkg.ExtractSearchQueries("no search section"); len(q) != 0 {
+		t.Fatalf("expected none, got %v", q)
+	}
+}
+
+func TestEnhancedSystemCompletionAddsResults(t *testing.T) {
+	var req openai.ChatCompletionRequest
+	client, srv := newOAITestClient(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		_ = json.NewEncoder(w).Encode(openai.ChatCompletionResponse{Choices: []openai.ChatCompletionChoice{{Message: openai.ChatCompletionMessage{Content: "ok"}}}})
+	})
+	defer srv.Close()
+
+	searchSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"RelatedTopics": []map[string]any{
+				{"Text": "Result text", "FirstURL": "https://example.com"},
+			},
+		})
+	}))
+	botpkg.SearchHTTPClient = searchSrv.Client()
+	botpkg.SearchBaseURL = searchSrv.URL + "/"
+	defer func() {
+		botpkg.SearchHTTPClient = http.DefaultClient
+		botpkg.SearchBaseURL = "https://duckduckgo.com/"
+	}()
+	defer searchSrv.Close()
+
+	prompt := "test\n🔍 ВЕБ-ПОИСК: Найди новости\n- \"query\""
+	_, err := botpkg.EnhancedSystemCompletion(context.Background(), client, prompt, "o3")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	content := req.Messages[0].Content
+	if !strings.Contains(content, "Result text") {
+		t.Errorf("search results not appended: %s", content)
+	}
+}
+
+func TestEnhancedSystemCompletionSearchError(t *testing.T) {
+	var req openai.ChatCompletionRequest
+	client, srv := newOAITestClient(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		_ = json.NewEncoder(w).Encode(openai.ChatCompletionResponse{Choices: []openai.ChatCompletionChoice{{Message: openai.ChatCompletionMessage{Content: "ok"}}}})
+	})
+	defer srv.Close()
+
+	botpkg.SearchHTTPClient = &http.Client{Transport: searchRoundTripperFunc(func(*http.Request) (*http.Response, error) { return nil, http.ErrHandlerTimeout })}
+	botpkg.SearchBaseURL = "https://example.com/"
+	defer func() {
+		botpkg.SearchHTTPClient = http.DefaultClient
+		botpkg.SearchBaseURL = "https://duckduckgo.com/"
+	}()
+
+	prompt := "test\n🔍 ВЕБ-ПОИСК: Найди новости\n- \"query\""
+	_, err := botpkg.EnhancedSystemCompletion(context.Background(), client, prompt, "o3")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(req.Messages[0].Content, "query") && strings.Contains(req.Messages[0].Content, "https://") {
+		t.Errorf("search results should not be appended on error")
+	}
+}
+
+func TestEnhancedSystemCompletionNoResults(t *testing.T) {
+	var req openai.ChatCompletionRequest
+	client, srv := newOAITestClient(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		_ = json.NewEncoder(w).Encode(openai.ChatCompletionResponse{Choices: []openai.ChatCompletionChoice{{Message: openai.ChatCompletionMessage{Content: "ok"}}}})
+	})
+	defer srv.Close()
+
+	searchSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{"RelatedTopics": []any{}})
+	}))
+	botpkg.SearchHTTPClient = searchSrv.Client()
+	botpkg.SearchBaseURL = searchSrv.URL + "/"
+	defer func() {
+		botpkg.SearchHTTPClient = http.DefaultClient
+		botpkg.SearchBaseURL = "https://duckduckgo.com/"
+	}()
+	defer searchSrv.Close()
+
+	prompt := "test\n🔍 ВЕБ-ПОИСК: Найди новости\n- \"query\""
+	_, err := botpkg.EnhancedSystemCompletion(context.Background(), client, prompt, "o3")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(req.Messages[0].Content, "Result text") {
+		t.Errorf("expected no appended results")
+	}
+}
+
+type searchRoundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f searchRoundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}


### PR DESCRIPTION
## Summary
- implement DuckDuckGo search helpers
- extend `EnhancedSystemCompletion` to integrate search results
- add unit tests for `ExtractSearchQueries` and `EnhancedSystemCompletion`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687f495142ac832e93c9cb56ea555408