### PR TITLE
Add web search configuration options

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,4 +7,6 @@ BRIEF_TIME=20:00
 TASKS_FILE=tasks.yml
 WHITELIST_FILE=whitelist.json
 BLOCKCHAIN_API=https://api.blockchain.info/stats
+ENABLE_WEB_SEARCH=false
+SEARCH_PROVIDER_URL=https://api.duckduckgo.com
 DOCKERHUB_USER=your_dockerhub_username

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@
 * Путь к файлу задач (`TASKS_FILE`) или JSON в `TASKS_JSON` для полной настройки расписания
 * Путь к файлу whitelist (`WHITELIST_FILE`, опционально, по умолчанию `whitelist.json`)
 * URL API блокчейна (`BLOCKCHAIN_API`, опционально, по умолчанию `https://api.blockchain.info/stats`)
+* Включить веб-поиск (`ENABLE_WEB_SEARCH`, опционально, по умолчанию `false`)
+* URL поискового провайдера (`SEARCH_PROVIDER_URL`, опционально, по умолчанию `https://api.duckduckgo.com`)
 * Уровень логирования (`LOG_LEVEL`, опционально, `debug`, `info`, `warn` или `error`)
 * ID чата для логов (`LOG_CHAT_ID`, опционально)
 
@@ -157,6 +159,8 @@ go run main.go
 - `TASKS_FILE` – путь к YAML-файлу с пользовательскими заданиями
 - `WHITELIST_FILE` – путь к файлу со списком чатов (по умолчанию `whitelist.json`)
 - `BLOCKCHAIN_API` – URL API блокчейна для команды `/blockchain`
+- `ENABLE_WEB_SEARCH` – включить веб-поиск (по умолчанию `false`)
+- `SEARCH_PROVIDER_URL` – URL поискового провайдера (по умолчанию `https://api.duckduckgo.com`)
 - `LOG_LEVEL` – уровень логирования (`debug`, `info`, `warn` или `error`)
 
 Пример `.env` и `tasks.yml`:
@@ -170,6 +174,8 @@ BRIEF_TIME=18:00
 TASKS_FILE=tasks.yml
 WHITELIST_FILE=whitelist.json
 BLOCKCHAIN_API=https://api.blockchain.info/stats
+ENABLE_WEB_SEARCH=false
+SEARCH_PROVIDER_URL=https://api.duckduckgo.com
 LOG_CHAT_ID=123456789
 ```
 
@@ -280,6 +286,8 @@ BRIEF_TIME=20:00
 # CHAT_ID=123456789
 # WHITELIST_FILE=whitelist.json
 # BLOCKCHAIN_API=https://api.blockchain.info/stats
+# ENABLE_WEB_SEARCH=false
+# SEARCH_PROVIDER_URL=https://api.duckduckgo.com
 ```
 
 Если контейнер не стартует, проверьте логи командой `docker logs <container>`, чтобы увидеть сообщения об ошибках.

--- a/config_test.go
+++ b/config_test.go
@@ -13,12 +13,14 @@ func TestLoadConfigSuccess(t *testing.T) {
 	t.Setenv(config.EnvOpenAIKey, "key")
 	t.Setenv(config.EnvOpenAIModel, "model")
 	t.Setenv(config.EnvBlockchainAPI, "http://example.com")
+	t.Setenv(config.EnvEnableWebSearch, "true")
+	t.Setenv(config.EnvSearchProviderURL, "http://search")
 
 	cfg, err := config.Load()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cfg.TelegramToken != "token" || cfg.ChatID != 99 || cfg.LogChatID != 100 || cfg.OpenAIKey != "key" || cfg.OpenAIModel != "model" || cfg.BlockchainAPI != "http://example.com" {
+	if cfg.TelegramToken != "token" || cfg.ChatID != 99 || cfg.LogChatID != 100 || cfg.OpenAIKey != "key" || cfg.OpenAIModel != "model" || cfg.BlockchainAPI != "http://example.com" || !cfg.EnableWebSearch || cfg.SearchProviderURL != "http://search" {
 		t.Fatalf("unexpected values: %+v", cfg)
 	}
 }
@@ -69,5 +71,20 @@ func TestLoadConfigBadLogChatID(t *testing.T) {
 	_, err := config.Load()
 	if err == nil {
 		t.Fatal("expected error")
+	}
+}
+
+func TestLoadConfigDefaults(t *testing.T) {
+	t.Setenv(config.EnvTelegramToken, "token")
+	t.Setenv(config.EnvOpenAIKey, "key")
+	t.Setenv(config.EnvEnableWebSearch, "")
+	t.Setenv(config.EnvSearchProviderURL, "")
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.EnableWebSearch != false || cfg.SearchProviderURL == "" {
+		t.Fatalf("unexpected defaults: %+v", cfg)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,24 +8,29 @@ import (
 
 // Environment variable names
 const (
-	EnvTelegramToken = "TELEGRAM_TOKEN"
-	EnvChatID        = "CHAT_ID"
-	EnvLogChatID     = "LOG_CHAT_ID"
-	EnvOpenAIKey     = "OPENAI_API_KEY"
-	EnvOpenAIModel   = "OPENAI_MODEL"
-	EnvBlockchainAPI = "BLOCKCHAIN_API"
+	EnvTelegramToken     = "TELEGRAM_TOKEN"
+	EnvChatID            = "CHAT_ID"
+	EnvLogChatID         = "LOG_CHAT_ID"
+	EnvOpenAIKey         = "OPENAI_API_KEY"
+	EnvOpenAIModel       = "OPENAI_MODEL"
+	EnvBlockchainAPI     = "BLOCKCHAIN_API"
+	EnvEnableWebSearch   = "ENABLE_WEB_SEARCH"
+	EnvSearchProviderURL = "SEARCH_PROVIDER_URL"
 )
 
 const DefaultBlockchainAPI = "https://api.blockchain.info/stats"
+const DefaultSearchProviderURL = "https://api.duckduckgo.com"
 
 // Config holds environment configuration values.
 type Config struct {
-	TelegramToken string
-	ChatID        int64
-	LogChatID     int64
-	OpenAIKey     string
-	OpenAIModel   string
-	BlockchainAPI string
+	TelegramToken     string
+	ChatID            int64
+	LogChatID         int64
+	OpenAIKey         string
+	OpenAIModel       string
+	BlockchainAPI     string
+	EnableWebSearch   bool
+	SearchProviderURL string
 }
 
 // Load reads environment variables and validates them.
@@ -38,6 +43,8 @@ func Load() (Config, error) {
 	openaiKey := os.Getenv(EnvOpenAIKey)
 	openaiModel := os.Getenv(EnvOpenAIModel)
 	blockchainAPI := os.Getenv(EnvBlockchainAPI)
+	enableWebSearchStr := os.Getenv(EnvEnableWebSearch)
+	searchProviderURL := os.Getenv(EnvSearchProviderURL)
 
 	if telegramToken == "" || openaiKey == "" {
 		return cfg, fmt.Errorf("missing required env vars")
@@ -61,17 +68,31 @@ func Load() (Config, error) {
 		}
 	}
 
+	enableWebSearch := false
+	if enableWebSearchStr != "" {
+		var err error
+		enableWebSearch, err = strconv.ParseBool(enableWebSearchStr)
+		if err != nil {
+			return cfg, fmt.Errorf("invalid ENABLE_WEB_SEARCH: %w", err)
+		}
+	}
+
 	if blockchainAPI == "" {
 		blockchainAPI = DefaultBlockchainAPI
 	}
+	if searchProviderURL == "" {
+		searchProviderURL = DefaultSearchProviderURL
+	}
 
 	cfg = Config{
-		TelegramToken: telegramToken,
-		ChatID:        chatID,
-		LogChatID:     logChatID,
-		OpenAIKey:     openaiKey,
-		OpenAIModel:   openaiModel,
-		BlockchainAPI: blockchainAPI,
+		TelegramToken:     telegramToken,
+		ChatID:            chatID,
+		LogChatID:         logChatID,
+		OpenAIKey:         openaiKey,
+		OpenAIModel:       openaiModel,
+		BlockchainAPI:     blockchainAPI,
+		EnableWebSearch:   enableWebSearch,
+		SearchProviderURL: searchProviderURL,
 	}
 
 	return cfg, nil


### PR DESCRIPTION
## Summary
- extend config with web search settings
- read new options from environment variables
- document ENABLE_WEB_SEARCH and SEARCH_PROVIDER_URL
- update example config
- test configuration defaults and parsing

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687f4952ab58832e86d47d3b7d9ec173