### PR TITLE
Enable web search by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@
 * Путь к файлу задач (`TASKS_FILE`) или JSON в `TASKS_JSON` для полной настройки расписания
 * Путь к файлу whitelist (`WHITELIST_FILE`, опционально, по умолчанию `whitelist.json`)
 * URL API блокчейна (`BLOCKCHAIN_API`, опционально, по умолчанию `https://api.blockchain.info/stats`)
-* Включить веб-поиск (`ENABLE_WEB_SEARCH`, `true`/`false`, по умолчанию `false`)
+* Включить веб-поиск (`ENABLE_WEB_SEARCH`, `true`/`false`, по умолчанию `true`)
 * URL провайдера поиска (`SEARCH_PROVIDER_URL`, опционально)
 * Уровень логирования (`LOG_LEVEL`, опционально, `debug`, `info`, `warn` или `error`)
 * ID чата для логов (`LOG_CHAT_ID`, опционально)
@@ -159,7 +159,7 @@ go run main.go
 - `TASKS_FILE` – путь к YAML-файлу с пользовательскими заданиями
 - `WHITELIST_FILE` – путь к файлу со списком чатов (по умолчанию `whitelist.json`)
 - `BLOCKCHAIN_API` – URL API блокчейна для команды `/blockchain`
-- `ENABLE_WEB_SEARCH` – включить веб-поиск (`true`/`false`)
+ - `ENABLE_WEB_SEARCH` – включить веб-поиск (`true`/`false`, по умолчанию `true`)
 - `SEARCH_PROVIDER_URL` – URL провайдера поиска (опционально)
 - `LOG_LEVEL` – уровень логирования (`debug`, `info`, `warn` или `error`)
 

--- a/internal/bot/openai_helper.go
+++ b/internal/bot/openai_helper.go
@@ -9,7 +9,7 @@ import (
 	openai "github.com/sashabaranov/go-openai"
 )
 
-var webSearchTool = openai.Tool{Type: openai.ToolType("web_search")}
+var webSearchTool = openai.Tool{Type: openai.ToolType("web_search_preview")}
 
 func supportsWebSearch(model string) bool {
 	for _, m := range SupportedModels {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -73,7 +73,10 @@ func Load() (Config, error) {
 		blockchainAPI = DefaultBlockchainAPI
 	}
 
-	enableWebSearch := enableWebSearchStr == "1" || strings.ToLower(enableWebSearchStr) == "true"
+	enableWebSearch := true
+	if enableWebSearchStr != "" {
+		enableWebSearch = enableWebSearchStr == "1" || strings.ToLower(enableWebSearchStr) == "true"
+	}
 
 	if searchProviderURL == "" {
 		searchProviderURL = DefaultSearchProviderURL


### PR DESCRIPTION
## Summary
- use `web_search_preview` tool when interacting with OpenAI
- default ENABLE_WEB_SEARCH env to true
- document new default value in README

## Testing
- `gofmt -w -s internal/config/config.go internal/bot/openai_helper.go`
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_687f7e3fcc04832e903a21ce499fad6c