### PR TITLE
Enable built-in tools with responses API

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,50 @@ BRIEF_TIME=20:00
 
 На Ubuntu VPS логи сервиса, запущенного через `systemd`, можно смотреть командой `journalctl -u telegram-reminder -f`. Если бот работает в Docker, используйте `docker logs -f telegram-reminder`.
 
+## Использование built-in tools
+
+Модели серии `gpt-4.1` поддерживают вызов встроенных инструментов через API `responses`.
+Пример использования с веб‑поиском:
+
+```javascript
+import OpenAI from "openai";
+const client = new OpenAI();
+
+const response = await client.responses.create({
+    model: "gpt-4.1",
+    tools: [{ type: "web_search_preview" }],
+    input: "What was a positive news story from today?",
+});
+
+console.log(response.output_text);
+```
+
+```python
+from openai import OpenAI
+client = OpenAI()
+
+response = client.responses.create(
+    model="gpt-4.1",
+    tools=[{"type": "web_search_preview"}],
+    input="What was a positive news story from today?"
+)
+
+print(response.output_text)
+```
+
+```bash
+curl "https://api.openai.com/v1/responses" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $OPENAI_API_KEY" \
+    -d '{
+        "model": "gpt-4.1",
+        "tools": [{"type": "web_search_preview"}],
+        "input": "what was a positive news story from today?"
+    }'
+```
+
+Инструмент `web_search_preview` позволяет модели получать свежие данные из интернета.
+
 ## Лицензия
 
 Проект распространяется на условиях [MIT License](LICENSE).

--- a/internal/bot/openai_responses.go
+++ b/internal/bot/openai_responses.go
@@ -1,0 +1,75 @@
+package bot
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// ResponsesEndpoint defines the OpenAI API endpoint for responses. Tests can override it.
+var ResponsesEndpoint = "https://api.openai.com/v1/responses"
+
+// ResponseRequest is the payload for the /v1/responses endpoint.
+type ResponseRequest struct {
+	Model string         `json:"model"`
+	Tools []ResponseTool `json:"tools,omitempty"`
+	Input string         `json:"input"`
+}
+
+type ResponseTool struct {
+	Type string `json:"type"`
+}
+
+// responseResult is the minimal response structure we care about.
+type responseResult struct {
+	OutputText string `json:"output_text"`
+}
+
+// callResponsesAPI performs a request to the given responses endpoint.
+func callResponsesAPI(ctx context.Context, apiKey string, reqBody ResponseRequest, endpoint string) (string, error) {
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", err
+	}
+	if endpoint == "" {
+		endpoint = ResponsesEndpoint
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	httpReq.Header.Set("Authorization", fmt.Sprintf("Bearer %s", apiKey))
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: OpenAITimeout}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		data, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("openai error: %s", strings.TrimSpace(string(data)))
+	}
+	var res responseResult
+	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(res.OutputText), nil
+}
+
+// ResponsesCompletion sends input to the OpenAI responses API and returns output text.
+func ResponsesCompletion(ctx context.Context, apiKey, input, model string) (string, error) {
+	req := ResponseRequest{
+		Model: model,
+		Input: input,
+	}
+	if EnableWebSearch && supportsWebSearch(model) {
+		req.Tools = []ResponseTool{{Type: "web_search_preview"}}
+	}
+	return callResponsesAPI(ctx, apiKey, req, "")
+}

--- a/openai_responses_test.go
+++ b/openai_responses_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	botpkg "telegram-reminder/internal/bot"
+)
+
+func TestResponsesCompletion(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req botpkg.ResponseRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if req.Model != "gpt-4.1" {
+			t.Fatalf("model: %s", req.Model)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"output_text":"ok"}`))
+	}))
+	defer srv.Close()
+
+	botpkg.ResponsesEndpoint = srv.URL + "/v1/responses"
+	ctx := context.Background()
+	out, err := botpkg.ResponsesCompletion(ctx, "test-key", "hi", "gpt-4.1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out != "ok" {
+		t.Fatalf("unexpected output: %s", out)
+	}
+}


### PR DESCRIPTION
## Summary
- add example in README for using built-in web search tool
- introduce `ResponsesCompletion` for OpenAI responses endpoint
- add unit test for the new function

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687fdbb673b8832e8fc2bf162a472f39