### PR TITLE
Improve web search integration

### DIFF
--- a/internal/bot/app.go
+++ b/internal/bot/app.go
@@ -29,6 +29,7 @@ func New(cfg config.Config) (*Bot, error) {
 		CurrentModel = cfg.OpenAIModel
 	}
 	EnableWebSearch = cfg.EnableWebSearch
+	SearchProviderURL = cfg.SearchProviderURL
 
 	tele, err := tb.NewBot(tb.Settings{Token: cfg.TelegramToken})
 	if err != nil {


### PR DESCRIPTION
## Summary
- add `SearchProviderURL` config to web search helper
- implement actual search call and tool call handling

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687ffad875fc832ebb51ace36cae3954