### PR TITLE
Use TOKEN_GITHUB secret for MCP deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -141,3 +141,30 @@ jobs:
 
             echo "[🎉] Деплой завершён успешно."
           EOF
+  deploy-mcp:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.TOKEN_GITHUB }}
+      - name: Deploy GitHub MCP to VPS via SSH
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          script: |
+            docker pull ghcr.io/github/github-mcp-server:latest
+            docker rm -f github-mcp-server || true
+            docker run -d \
+              --name github-mcp-server \
+              --restart unless-stopped \
+              -e GITHUB_PERSONAL_ACCESS_TOKEN="${{ secrets.TOKEN_GITHUB }}" \
+              ghcr.io/github/github-mcp-server:latest
+


### PR DESCRIPTION
## Summary
- update MCP deployment job to use `TOKEN_GITHUB` secret when logging into GHCR and running the container

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68813432b244832e9d2712619e7c37ca