### PR TITLE
Switch OpenAI search to new responses API

### DIFF
--- a/internal/bot/openai_search.go
+++ b/internal/bot/openai_search.go
@@ -1,17 +1,34 @@
 package bot
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
+	"net/http"
 	"os"
+	"regexp"
+	"strings"
 	"time"
 
 	"telegram-reminder/internal/logger"
 )
 
+// markdownToTelegramHTML converts a subset of Markdown to Telegram-compatible HTML.
+func markdownToTelegramHTML(input string) string {
+	reBold := regexp.MustCompile(`\*\*(.*?)\*\*`)
+	input = reBold.ReplaceAllString(input, "<b>$1</b>")
+
+	reLink := regexp.MustCompile(`\[(.*?)\]\((.*?)\)`)
+	input = reLink.ReplaceAllString(input, `<a href="$2">$1</a>`)
+
+	return input
+}
+
 // OpenAISearch performs a web search using the OpenAI responses API and returns
-// plain text results. It relies on the current model and web search being
-// enabled.
+// the result formatted for Telegram HTML.
 func OpenAISearch(query string) (string, error) {
 	logger.L.Debug("openai search", "query", query)
 	apiKey := os.Getenv("OPENAI_API_KEY")
@@ -22,11 +39,74 @@ func OpenAISearch(query string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	res, err := ResponsesCompletion(ctx, apiKey, query, CurrentModel)
+	reqBody := map[string]any{
+		"model": CurrentModel,
+		"input": []map[string]string{{"role": "user", "content": query}},
+		"tools": []map[string]any{
+			{
+				"type": "function",
+				"function": map[string]any{
+					"name":        "web_search",
+					"description": "Search the web for information",
+					"parameters": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"query": map[string]string{
+								"type":        "string",
+								"description": "Search query",
+							},
+						},
+						"required": []string{"query"},
+					},
+				},
+			},
+		},
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ResponsesEndpoint, bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", apiKey))
+	req.Header.Set("Content-Type", "application/json")
+
+	client := logger.NewHTTPClient(OpenAITimeout)
+	resp, err := client.Do(req)
 	if err != nil {
 		logger.L.Debug("openai search error", "err", err)
 		return "", err
 	}
-	logger.L.Debug("openai search result", "bytes", len(res))
-	return res, nil
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= http.StatusBadRequest {
+		data, _ := io.ReadAll(resp.Body)
+		err := fmt.Errorf("openai error: %s", strings.TrimSpace(string(data)))
+		logger.L.Debug("openai search status", "status", resp.Status)
+		return "", err
+	}
+
+	var res struct {
+		Output []struct {
+			Type    string `json:"type"`
+			Content []struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			} `json:"content"`
+		} `json:"output"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
+		logger.L.Debug("openai search decode", "err", err)
+		return "", err
+	}
+	if len(res.Output) < 2 || len(res.Output[1].Content) == 0 {
+		return "", errors.New("openai: empty response")
+	}
+
+	out := markdownToTelegramHTML(res.Output[1].Content[0].Text)
+	logger.L.Debug("openai search result", "bytes", len(out))
+	return out, nil
 }


### PR DESCRIPTION
## Summary
- use the `web_search` function when performing /responses search
- format markdown returned by OpenAI into Telegram HTML

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68848425716c832eb9e9811ed72d51dc