### PR TITLE
Support BuildKit secrets

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,4 +4,5 @@
 bot
 /bin
 /dist
+.env*
 

--- a/.env.example
+++ b/.env.example
@@ -10,4 +10,6 @@ WHITELIST_FILE=whitelist.json
 BLOCKCHAIN_API=https://api.blockchain.info/stats
 ENABLE_WEB_SEARCH=true
 SEARCH_PROVIDER_URL=
+LOG_LEVEL=info
+LOG_CHAT_ID=
 DOCKERHUB_USER=your_dockerhub_username

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,10 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 COPY . .
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=secret,id=env \
+    if [ -f /run/secrets/env ]; then \
+        set -o allexport && . /run/secrets/env && set +o allexport; \
+    fi && \
     CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build -ldflags="-s -w" -o /bot ./cmd/bot
 

--- a/README.md
+++ b/README.md
@@ -234,14 +234,14 @@ go run ./cmd/bot
 Соберите образ для текущей платформы:
 
 ```sh
-docker build --env-file .env -t telegram-bot .
+DOCKER_BUILDKIT=1 docker build --secret id=env,src=.env -t telegram-bot .
 ```
 
 Для сборки и публикации мультиархитектурного образа (linux/amd64 и linux/arm64) с помощью `buildx`:
 
 ```sh
-docker buildx build --platform linux/amd64,linux/arm64 \
-  --env-file .env \
+DOCKER_BUILDKIT=1 docker buildx build --platform linux/amd64,linux/arm64 \
+  --secret id=env,src=.env \
   -t your_dockerhub_user/telegram-bot:latest --push .
 ```
 


### PR DESCRIPTION
## Summary
- ignore `.env` files during docker build
- load secrets conditionally in Dockerfile
- document enabling BuildKit when building

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6884d3216e0c832e919e053493b22ae4