### PR TITLE
Set error logging as default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,4 +10,5 @@ WHITELIST_FILE=whitelist.json
 BLOCKCHAIN_API=https://api.blockchain.info/stats
 ENABLE_WEB_SEARCH=true
 SEARCH_PROVIDER_URL=
+LOG_LEVEL=error
 DOCKERHUB_USER=your_dockerhub_username

--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ export TELEGRAM_TOKEN=your_telegram_token
 export OPENAI_API_KEY=your_openai_key
 export LUNCH_TIME=13:00
 export BRIEF_TIME=20:00
-export LOG_LEVEL=debug
-# подробные логи всех задач и запросов к OpenAI
+export LOG_LEVEL=error
+# уровень логов: только ошибки
 
 # опционально задайте начальный чат
 # export CHAT_ID=123456789

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -34,14 +34,16 @@ func parseLevel(l string) slog.Level {
 	switch strings.ToLower(l) {
 	case "debug":
 		return slog.LevelDebug
-	case "info", "":
+	case "info":
 		return slog.LevelInfo
+	case "":
+		return slog.LevelError
 	case "warn", "warning":
 		return slog.LevelWarn
 	case "error":
 		return slog.LevelError
 	default:
-		return slog.LevelInfo
+		return slog.LevelError
 	}
 }
 


### PR DESCRIPTION
## Summary
- default to error logging when LOG_LEVEL is unset or invalid
- update example environment file with `LOG_LEVEL=error`
- document the new default log level in README

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6884fbca5fb0832eaa8fb3f795e5a903