### PR TITLE
Fix empty message handling

### DIFF
--- a/internal/bot/openai_helper.go
+++ b/internal/bot/openai_helper.go
@@ -78,6 +78,14 @@ type ChatCompleter interface {
 //   - error: Any error that occurred during the API call
 func ChatCompletion(ctx context.Context, client ChatCompleter, msgs []openai.ChatCompletionMessage, model string) (string, error) {
 	logger.L.Debug("chat completion", "model", model, "messages", len(msgs))
+	if len(msgs) == 0 {
+		return "", nil
+	}
+	for _, m := range msgs {
+		if strings.TrimSpace(m.Content) == "" {
+			return "", nil
+		}
+	}
 	// Append current date and time as a system message
 	timeMsg := openai.ChatCompletionMessage{
 		Role:    openai.ChatMessageRoleSystem,


### PR DESCRIPTION
## Summary
- avoid sending an OpenAI request when a chat message has empty content

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6885004dc1a0832eb2bc5916cfee0cb3