### PR TITLE
Handle empty web search result

### DIFF
--- a/internal/bot/openai_helper.go
+++ b/internal/bot/openai_helper.go
@@ -136,6 +136,9 @@ func ChatCompletion(ctx context.Context, client ChatCompleter, msgs []openai.Cha
 			if err != nil {
 				res = err.Error()
 			}
+			if strings.TrimSpace(res) == "" {
+				res = "no results"
+			}
 			toolMsgs = append(toolMsgs, openai.ChatCompletionMessage{
 				Role:       openai.ChatMessageRoleTool,
 				ToolCallID: tc.ID,

--- a/internal/bot/search_test.go
+++ b/internal/bot/search_test.go
@@ -1,0 +1,62 @@
+package bot
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	openai "github.com/sashabaranov/go-openai"
+)
+
+type toolCallClient struct {
+	t      *testing.T
+	called int
+}
+
+func (c *toolCallClient) CreateChatCompletion(ctx context.Context, req openai.ChatCompletionRequest) (openai.ChatCompletionResponse, error) {
+	if c.called == 0 {
+		c.called++
+		return openai.ChatCompletionResponse{Choices: []openai.ChatCompletionChoice{{
+			Message: openai.ChatCompletionMessage{
+				ToolCalls: []openai.ToolCall{{
+					ID:   "1",
+					Type: openai.ToolTypeFunction,
+					Function: openai.FunctionCall{
+						Name:      "web_search",
+						Arguments: `{"query":"test"}`,
+					},
+				}},
+			},
+		}}}, nil
+	}
+	if len(req.Messages) == 0 {
+		c.t.Fatalf("no messages in second request")
+	}
+	msg := req.Messages[len(req.Messages)-1]
+	if msg.Content == "" {
+		return openai.ChatCompletionResponse{}, errors.New("empty content")
+	}
+	return openai.ChatCompletionResponse{Choices: []openai.ChatCompletionChoice{{
+		Message: openai.ChatCompletionMessage{Content: "ok"},
+	}}}, nil
+}
+
+func TestChatCompletionEmptySearchResult(t *testing.T) {
+	origSearch := searchFunc
+	searchFunc = func(ctx context.Context, q string) (string, error) { return "", nil }
+	defer func() { searchFunc = origSearch }()
+	origWeb := EnableWebSearch
+	EnableWebSearch = true
+	defer func() { EnableWebSearch = origWeb }()
+
+	client := &toolCallClient{t: t}
+	ctx := context.Background()
+	msgs := []openai.ChatCompletionMessage{{Role: openai.ChatMessageRoleUser, Content: "hi"}}
+	resp, err := ChatCompletion(ctx, client, msgs, "gpt-4.1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp != "ok" {
+		t.Fatalf("unexpected response %q", resp)
+	}
+}


### PR DESCRIPTION
## Summary
- avoid creating an invalid tool message when web search returns no output
- cover the web search workflow with a new test

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68850748af68832e905b02f9160f23ff