### PR TITLE
Increase OpenAI request timeouts

### DIFF
--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -60,7 +60,11 @@ const (
 `
 )
 
-const OpenAITimeout = 3 * time.Minute
+// OpenAITimeout defines how long the bot waits for a response from OpenAI.
+// The previous value of 3 minutes was occasionally insufficient for
+// complex prompts. Increasing the timeout helps prevent premature
+// cancellation of requests.
+const OpenAITimeout = 5 * time.Minute
 const BlockchainTimeout = 10 * time.Second
 
 const TelegramMessageLimit = 4096

--- a/internal/bot/openai_search.go
+++ b/internal/bot/openai_search.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"os"
-	"time"
 
 	"telegram-reminder/internal/logger"
 )
@@ -18,7 +17,9 @@ func OpenAISearch(query string) (string, error) {
 		return "", errors.New("OPENAI_API_KEY not set")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	// Use the same timeout as other OpenAI requests to avoid early
+	// cancellation when search results take longer to generate.
+	ctx, cancel := context.WithTimeout(context.Background(), OpenAITimeout)
 	defer cancel()
 
 	out, err := ChatResponses(ctx, apiKey, CurrentModel, query)


### PR DESCRIPTION
## Summary
- raise `OpenAITimeout` to 5 minutes
- use the longer timeout in the OpenAI search helper

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68850b47c020832e95bd08b561413c72