### PR TITLE
Fix deploy heredoc termination

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -124,7 +124,7 @@ jobs:
             TASKS_JSON=${TASKS_JSON}
             WHITELIST_FILE=${WHITELIST_FILE}
             DOCKERHUB_USER=${DOCKERHUB_USER}
-            EOF
+          EOF
 
             echo "[📋] Содержимое .env:"
             cat .env
@@ -165,7 +165,7 @@ jobs:
             fi
 
             echo "[🎉] Деплой завершён успешно."
-          EOF
+          'EOF'
   deploy-mcp:
     needs: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- fix indentation in deploy workflow to close inner heredoc properly
- ensure outer heredoc delimiter matches opening quote

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68851c158b54832e9a76e387a0688692