### PR TITLE
Fix deploy heredoc closing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -124,7 +124,7 @@ jobs:
             TASKS_JSON=${TASKS_JSON}
             WHITELIST_FILE=${WHITELIST_FILE}
             DOCKERHUB_USER=${DOCKERHUB_USER}
-            EOF
+          EOF
 
             echo "[📋] Содержимое .env:"
             cat .env


### PR DESCRIPTION
## Summary
- ensure outer heredoc in deploy workflow uses unquoted closing delimiter

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68851c158b54832e9a76e387a0688692