### PR TITLE
Fix GitHub secrets expansion in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -106,7 +106,7 @@ jobs:
             echo "  OPENAI_MODEL: ${OPENAI_MODEL:-gpt-4.1}"
             echo "  DOCKERHUB_USER: ${DOCKERHUB_USER}"
 
-            cat <<'EOENV' > .env
+            cat <<EOENV > .env
             TELEGRAM_TOKEN=${TELEGRAM_TOKEN}
             OPENAI_API_KEY=${OPENAI_API_KEY}
             CHAT_ID=${CHAT_ID}


### PR DESCRIPTION
## Summary
- ensure variables in `.env` are expanded by removing the quoted heredoc in deploy workflow

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68852803e674832eb9dbd342b65643f5