### PR TITLE
Fix secret expansion in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Deploy to VPS
         run: |
-          ssh -o StrictHostKeyChecking=no ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }} <<'EOSSH'
+          ssh -o StrictHostKeyChecking=no ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }} <<EOSSH
             set -e
             cd /opt/telegram-reminder/telegram-reminder
 


### PR DESCRIPTION
## Summary
- ensure GitHub secrets expand when deploying over SSH

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68853d5baa88832ea4d1186f714da8c9