### PR TITLE
Fix deployment env generation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,97 +77,25 @@ jobs:
 
       - name: Deploy to VPS
         run: |
-          ssh -o StrictHostKeyChecking=no ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }} <<EOSSH
+          ssh -o StrictHostKeyChecking=no ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }} <<'EOSSH'
             set -e
             cd /opt/telegram-reminder/telegram-reminder
 
-            TELEGRAM_TOKEN="${{ secrets.TELEGRAM_TOKEN }}"
-            OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}"
-            CHAT_ID="${{ secrets.CHAT_ID }}"
-            LOG_CHAT_ID="${{ secrets.LOG_CHAT_ID }}"
-            OPENAI_MODEL="${{ secrets.OPENAI_MODEL }}"
-            OPENAI_MAX_TOKENS="${{ secrets.OPENAI_MAX_TOKENS }}"
-            OPENAI_TOOL_CHOICE="${{ secrets.OPENAI_TOOL_CHOICE }}"
-            LUNCH_TIME="${{ secrets.LUNCH_TIME }}"
-            BRIEF_TIME="${{ secrets.BRIEF_TIME }}"
-            BLOCKCHAIN_API="${{ secrets.BLOCKCHAIN_API }}"
-            ENABLE_WEB_SEARCH="${{ secrets.ENABLE_WEB_SEARCH }}"
-            LOG_LEVEL="${{ secrets.LOG_LEVEL }}"
-            TASKS_FILE="${{ secrets.TASKS_FILE }}"
-            WHITELIST_FILE="${{ secrets.WHITELIST_FILE }}"
-            TASKS_JSON="${{ secrets.TASKS_JSON }}"
-            DOCKERHUB_USER="${{ secrets.DOCKERHUB_USER }}"
-
-            echo "[📦] Обновляем .env..."
-            echo "[🔍] Отладочная информация:"
-            echo "  TELEGRAM_TOKEN: ${TELEGRAM_TOKEN:0:10}..."
-            echo "  OPENAI_API_KEY: ${OPENAI_API_KEY:0:10}..."
-            echo "  CHAT_ID: ${CHAT_ID:-НЕ_НАСТРОЕН}"
-            echo "  OPENAI_MODEL: ${OPENAI_MODEL:-gpt-4.1}"
-            echo "  DOCKERHUB_USER: ${DOCKERHUB_USER}"
-
-            cat <<EOENV > .env
-            TELEGRAM_TOKEN=${TELEGRAM_TOKEN}
-            OPENAI_API_KEY=${OPENAI_API_KEY}
-            CHAT_ID=${CHAT_ID}
-            LOG_CHAT_ID=${LOG_CHAT_ID}
-            OPENAI_MODEL=${OPENAI_MODEL}
-            OPENAI_MAX_TOKENS=${OPENAI_MAX_TOKENS}
-            OPENAI_TOOL_CHOICE=${OPENAI_TOOL_CHOICE}
-            LUNCH_TIME=${LUNCH_TIME}
-            BRIEF_TIME=${BRIEF_TIME}
-            BLOCKCHAIN_API=${BLOCKCHAIN_API}
-            ENABLE_WEB_SEARCH=${ENABLE_WEB_SEARCH}
-            LOG_LEVEL=${LOG_LEVEL}
-            TASKS_FILE=${TASKS_FILE:-tasks.yml}
-            TASKS_JSON=${TASKS_JSON}
-            WHITELIST_FILE=${WHITELIST_FILE}
-            DOCKERHUB_USER=${DOCKERHUB_USER}
-            EOENV
-            sed -i 's/^ *//' .env
+            cat <<EOF > .env
+            TELEGRAM_TOKEN=${{ secrets.TELEGRAM_TOKEN }}
+            OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
+            CHAT_ID=${{ secrets.CHAT_ID }}
+            LOG_CHAT_ID=${{ secrets.LOG_CHAT_ID }}
+            OPENAI_MODEL=${{ secrets.OPENAI_MODEL }}
+            DOCKERHUB_USER=${{ secrets.DOCKERHUB_USER }}
+              EOF
+              sed -i 's/^ *//' .env
 
             cat .env
-            docker exec telegram-reminder env | grep TELEGRAM
-
-            echo "[📋] Содержимое .env:"
-            cat .env
-
-            echo "[🔍] Проверяем docker-compose.yml..."
-            if [ ! -f docker-compose.yml ]; then
-              echo "[⚠️] Не найден docker-compose.yml — создаём..."
-              printf '%s\n' \
-                "services:" \
-                "  telegram-reminder:" \
-                "    image: ${DOCKERHUB_USER}/telegram-reminder:latest" \
-                "    container_name: telegram-reminder" \
-                "    restart: always" \
-                "    env_file:" \
-                "      - .env" > docker-compose.yml
-            fi
-
-            echo "[🐳] Пуллим образ и перезапускаем контейнер..."
-            docker pull ${DOCKERHUB_USER}/telegram-reminder:latest
-            docker rm -f telegram-reminder || true
+            docker compose pull
             docker compose down || true
             docker compose up -d
-
-            echo "[✅] Контейнер поднят. Проверяем статус..."
-            sleep 2
-            docker compose ps
-
-            echo "[🔍] Проверяем переменные окружения в контейнере..."
-            docker exec telegram-reminder env | grep -E "(OPENAI|TELEGRAM)" || echo "Контейнер еще не готов"
-
-            echo "[📋] Логи контейнера (последние 10 строк):"
-            docker logs telegram-reminder --tail 10 || echo "Логи недоступны"
-
-            echo "[✅] Проверка процесса..."
-            if ! docker inspect -f '{{.State.Running}}' telegram-reminder | grep true; then
-              echo "[❌] Контейнер не запущен"
-              exit 1
-            fi
-
-            echo "[🎉] Деплой завершён успешно."
+            docker exec telegram-reminder env | grep TELEGRAM || true
           EOSSH
 
   deploy-mcp:


### PR DESCRIPTION
## Summary
- simplify deploy job
- write exactly six environment variables to `.env`
- strip indentation from the generated file so variables contain no leading spaces
- show env values and container env check in logs

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68854148404c832eb7f147e9574da0ea