### PR TITLE
Improve OpenAI output logging

### DIFF
--- a/internal/bot/openai_helper.go
+++ b/internal/bot/openai_helper.go
@@ -171,7 +171,7 @@ func ChatCompletion(ctx context.Context, client ChatCompleter, msgs []openai.Cha
 		}
 	}
 	out := strings.TrimSpace(msg.Content)
-	logger.L.Debug("openai result", "length", len(out))
+	logger.L.Debug("openai result", "length", len(out), "preview", logger.Truncate(out, 200))
 	return out, nil
 }
 

--- a/internal/bot/openai_responses.go
+++ b/internal/bot/openai_responses.go
@@ -89,7 +89,7 @@ func callResponsesAPI(ctx context.Context, apiKey string, reqBody ResponseReques
 			logger.L.Debug("responses api empty output")
 			return "", errors.New("openai: empty response")
 		}
-		logger.L.Debug("responses api result", "bytes", len(out))
+		logger.L.Debug("responses api result", "bytes", len(out), "preview", logger.Truncate(out, 200))
 		return out, nil
 	}
 	data, err := io.ReadAll(resp.Body)
@@ -108,7 +108,7 @@ func callResponsesAPI(ctx context.Context, apiKey string, reqBody ResponseReques
 		logger.L.Debug("responses api empty output", "body", string(data))
 		return "", errors.New("openai: empty response")
 	}
-	logger.L.Debug("responses api result", "bytes", len(out))
+	logger.L.Debug("responses api result", "bytes", len(out), "preview", logger.Truncate(out, 200))
 	return out, nil
 }
 
@@ -205,6 +205,6 @@ func ChatResponses(ctx context.Context, apiKey, model, prompt string) (string, e
 		return "", errors.New("openai: empty response")
 	}
 	out = markdownToTelegramHTML(out)
-	logger.L.Debug("responses api result", "bytes", len(out))
+	logger.L.Debug("responses api result", "bytes", len(out), "preview", logger.Truncate(out, 200))
 	return out, nil
 }

--- a/internal/logger/util.go
+++ b/internal/logger/util.go
@@ -1,0 +1,10 @@
+package logger
+
+// Truncate returns the string truncated to maxLen runes. If the string is longer, it appends "...".
+func Truncate(s string, maxLen int) string {
+	r := []rune(s)
+	if len(r) <= maxLen {
+		return s
+	}
+	return string(r[:maxLen]) + "..."
+}


### PR DESCRIPTION
## Summary
- log a preview of OpenAI results instead of only the length
- add `logger.Truncate` helper for logging

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688546b61a84832e8ed2c48307cc13b1