### PR TITLE
Improve ResponsesCompletion streaming test

### DIFF
--- a/internal/bot/openai_responses.go
+++ b/internal/bot/openai_responses.go
@@ -76,9 +76,16 @@ func callResponsesAPI(ctx context.Context, apiKey string, reqBody ResponseReques
 			}
 			line = strings.TrimPrefix(line, "data:")
 			logger.L.Debug("responses api raw line", "line", line)
-			var chunk responseResult
+			var chunk struct {
+				Delta      *responseResult `json:"delta"`
+				OutputText string          `json:"output_text"`
+			}
 			if err := json.Unmarshal([]byte(line), &chunk); err == nil {
-				buf.WriteString(chunk.OutputText)
+				if chunk.OutputText != "" {
+					buf.WriteString(chunk.OutputText)
+				} else if chunk.Delta != nil {
+					buf.WriteString(chunk.Delta.OutputText)
+				}
 			}
 		}
 		if err := scanner.Err(); err != nil {


### PR DESCRIPTION
## Summary
- update ResponsesCompletion test to use SSE-style event/data lines
- parse `delta.output_text` chunks when streaming responses

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6886165698c4832e9fc45adcf0ddbb31