### PR TITLE
Improve web search output formatting

### DIFF
--- a/internal/bot/openai_search.go
+++ b/internal/bot/openai_search.go
@@ -18,6 +18,7 @@ func OpenAISearch(query string) (string, error) {
 		logger.L.Debug("openai search error", "err", err)
 		return "", err
 	}
+	out = markdownToTelegramHTML(out)
 	logger.L.Debug("openai search result", "bytes", len(out))
 	return out, nil
 }

--- a/internal/bot/openai_search_html_test.go
+++ b/internal/bot/openai_search_html_test.go
@@ -1,0 +1,27 @@
+package bot
+
+import (
+	"context"
+	"testing"
+)
+
+func TestOpenAISearchFormatting(t *testing.T) {
+	origAPI := searchAPIFunc
+	searchAPIFunc = func(ctx context.Context, q string) (string, error) {
+		return "**hi** [site](https://example.com)", nil
+	}
+	defer func() { searchAPIFunc = origAPI }()
+
+	searchMu.Lock()
+	searchCache = map[string]searchEntry{}
+	searchMu.Unlock()
+
+	out, err := OpenAISearch("test")
+	if err != nil {
+		t.Fatalf("search error: %v", err)
+	}
+	expected := "<b>hi</b> <a href=\"https://example.com\">site</a>"
+	if out != expected {
+		t.Fatalf("unexpected output: %q", out)
+	}
+}

--- a/internal/bot/telegram.go
+++ b/internal/bot/telegram.go
@@ -13,7 +13,7 @@ func sendLong(b *tb.Bot, to tb.Recipient, text string) error {
 		if len(runes) < end {
 			end = len(runes)
 		}
-		if _, err := b.Send(to, string(runes[:end])); err != nil {
+		if _, err := b.Send(to, string(runes[:end]), tb.ModeHTML); err != nil {
 			return err
 		}
 		runes = runes[end:]
@@ -30,7 +30,7 @@ func replyLong(c tb.Context, text string) error {
 		if len(runes) < end {
 			end = len(runes)
 		}
-		if err := c.Send(string(runes[:end])); err != nil {
+		if err := c.Send(string(runes[:end]), tb.ModeHTML); err != nil {
 			return err
 		}
 		runes = runes[end:]


### PR DESCRIPTION
## Summary
- format OpenAI search results for Telegram HTML
- send bot replies in HTML mode for long messages
- test formatting of the search output

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688a55898c7c832eb98325cb678d944d