### PR TITLE
Add OpenAI service tier options

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@
 * Имя модели OpenAI (`OPENAI_MODEL`, опционально, по умолчанию `gpt-4.1`)
 * Максимальное число токенов ответа (`OPENAI_MAX_TOKENS`, по умолчанию `600`)
 * Выбор использования tools (`OPENAI_TOOL_CHOICE`, по умолчанию `auto`)
+* Сервисный уровень OpenAI (`OPENAI_SERVICE_TIER`, опционально)
+* Усилие рассуждения (`OPENAI_REASONING_EFFORT`, опционально)
 * Время идей на обед (`LUNCH_TIME`, опционально, по умолчанию `13:00`)
 * Время вечернего дайджеста (`BRIEF_TIME`, опционально, по умолчанию `20:00`)
 * Путь к файлу задач (`TASKS_FILE`) или JSON в `TASKS_JSON` для полной настройки расписания
@@ -161,6 +163,8 @@ go run ./cmd/bot
 - `OPENAI_MODEL` – имя модели OpenAI (опционально, по умолчанию `gpt-4.1`)
 - `OPENAI_MAX_TOKENS` – максимальное число токенов ответа (по умолчанию `600`)
 - `OPENAI_TOOL_CHOICE` – режим tool calling (`auto` или `none`)
+- `OPENAI_SERVICE_TIER` – сервисный уровень обработки запроса (опционально)
+- `OPENAI_REASONING_EFFORT` – усилие рассуждения модели (опционально)
 - `LUNCH_TIME` – время для идей на обед
 - `BRIEF_TIME` – время вечернего дайджеста
 - `TASKS_FILE` – путь к YAML-файлу с пользовательскими заданиями
@@ -177,6 +181,8 @@ OPENAI_API_KEY=sk-xxxxxxxx
 OPENAI_MODEL=gpt-4.1
 OPENAI_MAX_TOKENS=600
 OPENAI_TOOL_CHOICE=auto
+OPENAI_SERVICE_TIER=default
+OPENAI_REASONING_EFFORT=medium
 LUNCH_TIME=12:00
 BRIEF_TIME=18:00
 TASKS_FILE=tasks.yml
@@ -291,6 +297,8 @@ OPENAI_API_KEY=sk-xxxxxxxx
 OPENAI_MODEL=gpt-4.1
 OPENAI_MAX_TOKENS=600
 OPENAI_TOOL_CHOICE=auto
+OPENAI_SERVICE_TIER=default
+OPENAI_REASONING_EFFORT=medium
 LUNCH_TIME=13:00
 BRIEF_TIME=20:00
 # CHAT_ID=123456789

--- a/internal/bot/app.go
+++ b/internal/bot/app.go
@@ -31,6 +31,8 @@ func New(cfg config.Config) (*Bot, error) {
 	}
 	EnableWebSearch = cfg.EnableWebSearch
 	OpenAIToolChoice = cfg.OpenAIToolChoice
+	OpenAIServiceTier = openai.ServiceTier(cfg.OpenAIServiceTier)
+	OpenAIReasoningEffort = cfg.OpenAIReasoningEffort
 
 	tele, err := tb.NewBot(tb.Settings{Token: cfg.TelegramToken})
 	if err != nil {

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -70,6 +70,8 @@ const BlockchainTimeout = 10 * time.Second
 const TelegramMessageLimit = 4096
 
 var OpenAIMaxTokens = 600
+var OpenAIServiceTier openai.ServiceTier
+var OpenAIReasoningEffort string
 
 const Version = "0.1.0"
 

--- a/internal/bot/openai_helper.go
+++ b/internal/bot/openai_helper.go
@@ -145,6 +145,12 @@ func ChatCompletion(ctx context.Context, client ChatCompleter, msgs []openai.Cha
 		Model:    model,
 		Messages: msgs,
 	}
+	if OpenAIServiceTier != "" {
+		req.ServiceTier = OpenAIServiceTier
+	}
+	if OpenAIReasoningEffort != "" {
+		req.ReasoningEffort = OpenAIReasoningEffort
+	}
 	if EnableWebSearch && supportsWebSearch(model) {
 		req.Tools = []openai.Tool{webSearchTool}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,30 +9,34 @@ import (
 
 // Environment variable names
 const (
-	EnvTelegramToken    = "TELEGRAM_TOKEN"
-	EnvChatID           = "CHAT_ID"
-	EnvLogChatID        = "LOG_CHAT_ID"
-	EnvOpenAIKey        = "OPENAI_API_KEY"
-	EnvOpenAIModel      = "OPENAI_MODEL"
-	EnvBlockchainAPI    = "BLOCKCHAIN_API"
-	EnvEnableWebSearch  = "ENABLE_WEB_SEARCH"
-	EnvOpenAIMaxTokens  = "OPENAI_MAX_TOKENS"
-	EnvOpenAIToolChoice = "OPENAI_TOOL_CHOICE"
+	EnvTelegramToken         = "TELEGRAM_TOKEN"
+	EnvChatID                = "CHAT_ID"
+	EnvLogChatID             = "LOG_CHAT_ID"
+	EnvOpenAIKey             = "OPENAI_API_KEY"
+	EnvOpenAIModel           = "OPENAI_MODEL"
+	EnvBlockchainAPI         = "BLOCKCHAIN_API"
+	EnvEnableWebSearch       = "ENABLE_WEB_SEARCH"
+	EnvOpenAIMaxTokens       = "OPENAI_MAX_TOKENS"
+	EnvOpenAIToolChoice      = "OPENAI_TOOL_CHOICE"
+	EnvOpenAIServiceTier     = "OPENAI_SERVICE_TIER"
+	EnvOpenAIReasoningEffort = "OPENAI_REASONING_EFFORT"
 )
 
 const DefaultBlockchainAPI = "https://api.blockchain.info/stats"
 
 // Config holds environment configuration values.
 type Config struct {
-	TelegramToken    string
-	ChatID           int64
-	LogChatID        int64
-	OpenAIKey        string
-	OpenAIModel      string
-	OpenAIMaxTokens  int
-	BlockchainAPI    string
-	EnableWebSearch  bool
-	OpenAIToolChoice string
+	TelegramToken         string
+	ChatID                int64
+	LogChatID             int64
+	OpenAIKey             string
+	OpenAIModel           string
+	OpenAIMaxTokens       int
+	BlockchainAPI         string
+	EnableWebSearch       bool
+	OpenAIToolChoice      string
+	OpenAIServiceTier     string
+	OpenAIReasoningEffort string
 }
 
 // Load reads environment variables and validates them.
@@ -51,6 +55,8 @@ func Load() (Config, error) {
 	enableWebSearchStr := os.Getenv(EnvEnableWebSearch)
 	maxTokensStr := os.Getenv(EnvOpenAIMaxTokens)
 	toolChoice := os.Getenv(EnvOpenAIToolChoice)
+	serviceTier := os.Getenv(EnvOpenAIServiceTier)
+	reasoningEffort := os.Getenv(EnvOpenAIReasoningEffort)
 
 	if telegramToken == "" || openaiKey == "" {
 		return cfg, fmt.Errorf("missing required env vars")
@@ -95,15 +101,17 @@ func Load() (Config, error) {
 	}
 
 	cfg = Config{
-		TelegramToken:    telegramToken,
-		ChatID:           chatID,
-		LogChatID:        logChatID,
-		OpenAIKey:        openaiKey,
-		OpenAIModel:      openaiModel,
-		OpenAIMaxTokens:  maxTokens,
-		BlockchainAPI:    blockchainAPI,
-		EnableWebSearch:  enableWebSearch,
-		OpenAIToolChoice: toolChoice,
+		TelegramToken:         telegramToken,
+		ChatID:                chatID,
+		LogChatID:             logChatID,
+		OpenAIKey:             openaiKey,
+		OpenAIModel:           openaiModel,
+		OpenAIMaxTokens:       maxTokens,
+		BlockchainAPI:         blockchainAPI,
+		EnableWebSearch:       enableWebSearch,
+		OpenAIToolChoice:      toolChoice,
+		OpenAIServiceTier:     serviceTier,
+		OpenAIReasoningEffort: reasoningEffort,
 	}
 
 	return cfg, nil

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -15,12 +15,14 @@ func TestLoadConfigSuccess(t *testing.T) {
 	t.Setenv(config.EnvBlockchainAPI, "http://example.com")
 	t.Setenv(config.EnvEnableWebSearch, "true")
 	t.Setenv(config.EnvOpenAIToolChoice, "none")
+	t.Setenv(config.EnvOpenAIServiceTier, "flex")
+	t.Setenv(config.EnvOpenAIReasoningEffort, "high")
 
 	cfg, err := config.Load()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cfg.TelegramToken != "token" || cfg.ChatID != 99 || cfg.LogChatID != 100 || cfg.OpenAIKey != "key" || cfg.OpenAIModel != "model" || cfg.BlockchainAPI != "http://example.com" || !cfg.EnableWebSearch || cfg.OpenAIToolChoice != "none" {
+	if cfg.TelegramToken != "token" || cfg.ChatID != 99 || cfg.LogChatID != 100 || cfg.OpenAIKey != "key" || cfg.OpenAIModel != "model" || cfg.BlockchainAPI != "http://example.com" || !cfg.EnableWebSearch || cfg.OpenAIToolChoice != "none" || cfg.OpenAIServiceTier != "flex" || cfg.OpenAIReasoningEffort != "high" {
 		t.Fatalf("unexpected values: %+v", cfg)
 	}
 }
@@ -79,6 +81,8 @@ func TestLoadConfigDefaults(t *testing.T) {
 	t.Setenv(config.EnvOpenAIKey, "key")
 	t.Setenv(config.EnvEnableWebSearch, "")
 	t.Setenv(config.EnvOpenAIToolChoice, "")
+	t.Setenv(config.EnvOpenAIServiceTier, "")
+	t.Setenv(config.EnvOpenAIReasoningEffort, "")
 
 	cfg, err := config.Load()
 	if err != nil {
@@ -89,5 +93,8 @@ func TestLoadConfigDefaults(t *testing.T) {
 	}
 	if cfg.OpenAIToolChoice != "auto" {
 		t.Fatalf("expected default tool choice 'auto'")
+	}
+	if cfg.OpenAIServiceTier != "" || cfg.OpenAIReasoningEffort != "" {
+		t.Fatalf("unexpected defaults: %+v", cfg)
 	}
 }


### PR DESCRIPTION
## Summary
- support setting `OPENAI_SERVICE_TIER` and `OPENAI_REASONING_EFFORT`
- propagate these options to ChatCompletion requests
- document new environment variables
- update configuration tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688a57beab5c832e99fdf1c68ab33416