### PR TITLE
Fix Telegram command list formatting

### DIFF
--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -3,6 +3,7 @@ package bot
 import (
 	"context"
 	"fmt"
+	"html"
 	"os"
 	"strings"
 	"sync"
@@ -135,7 +136,7 @@ var baseCommands = []string{
 func buildCommandsList(tasks []Task) string {
 	var sb strings.Builder
 	for _, cmd := range baseCommands {
-		sb.WriteString(cmd)
+		sb.WriteString(html.EscapeString(cmd))
 		sb.WriteByte('\n')
 	}
 	if len(tasks) > 0 {


### PR DESCRIPTION
## Summary
- escape angle brackets when listing commands to avoid Telegram parsing errors

## Testing
- `go test ./...`
- `go build ./cmd/bot`


------
https://chatgpt.com/codex/tasks/task_e_688a62684e18832ea13b9d186d1eedde