### PR TITLE
Fix empty response handling in OpenAI and Telegram functions

### DIFF
--- a/internal/bot/openai_helper.go
+++ b/internal/bot/openai_helper.go
@@ -308,6 +308,9 @@ func ChatCompletion(ctx context.Context, client ChatCompleter, msgs []openai.Cha
 	}
 	out := strings.TrimSpace(msg.Content)
 	logger.L.Debug("openai result", "length", len(out), "preview", logger.Truncate(out, 200))
+	if len(out) == 0 {
+		logger.L.Warn("empty openai response", "msg_content", msg.Content, "msg_role", msg.Role)
+	}
 	return out, nil
 }
 

--- a/internal/bot/telegram.go
+++ b/internal/bot/telegram.go
@@ -1,12 +1,20 @@
 package bot
 
 import (
+	"telegram-reminder/internal/logger"
+
 	tb "gopkg.in/telebot.v3"
 )
 
 // sendLong splits text into chunks that fit within Telegram's 4096 character
 // limit and sends them sequentially.
 func sendLong(b *tb.Bot, to tb.Recipient, text string) error {
+	if text == "" {
+		logger.L.Warn("empty text in sendLong")
+		_, err := b.Send(to, "❌ Получен пустой ответ")
+		return err
+	}
+	
 	runes := []rune(text)
 	for len(runes) > 0 {
 		end := TelegramMessageLimit
@@ -24,6 +32,11 @@ func sendLong(b *tb.Bot, to tb.Recipient, text string) error {
 // replyLong sends the text as a reply in the context's chat, splitting if
 // necessary.
 func replyLong(c tb.Context, text string) error {
+	if text == "" {
+		logger.L.Warn("empty text in replyLong")
+		return c.Send("❌ Получен пустой ответ")
+	}
+	
 	runes := []rune(text)
 	for len(runes) > 0 {
 		end := TelegramMessageLimit


### PR DESCRIPTION
## Problem
The `/lunch` command was silently failing when OpenAI returned empty responses, leaving users without any feedback.

## Solution
Added proper empty response handling:

### Changes Made
- **📝 Empty Text Validation**: Added checks in `sendLong()` and `replyLong()` functions
- **⚠️ Warning Logs**: Added warning when OpenAI returns empty response content
- **🔔 User Feedback**: Send "❌ Получен пустой ответ" instead of silent failure
- **🛡️ Error Prevention**: Prevent sending empty messages to Telegram

### Files Modified
- `internal/bot/telegram.go` - Added empty text validation
- `internal/bot/openai_helper.go` - Added empty response warning

## Test Results
✅ Code compiles successfully  
✅ Functions now provide user feedback instead of failing silently  

## Benefits
- **Better UX**: Users get immediate feedback when something goes wrong
- **Debugging**: Easier to identify when OpenAI returns empty responses
- **Reliability**: Prevents silent failures in message delivery

## Related Issue
Resolves the issue where `/lunch` command would execute successfully but send no response to the user.

🤖 Generated with [Claude Code](https://claude.ai/code)