### PR TITLE
Fix Telegram debug log spam

### DIFF
--- a/internal/bot/app.go
+++ b/internal/bot/app.go
@@ -66,7 +66,7 @@ func (b *Bot) Start() error {
 	logger.L.Info("authorized", "user", b.TeleBot.Me.Username)
 
 	if b.Config.LogChatID != 0 {
-		logger.EnableTelegramLogging(b.Config.TelegramToken, b.Config.LogChatID, slog.LevelDebug)
+		logger.EnableTelegramLogging(b.Config.TelegramToken, b.Config.LogChatID, slog.LevelError)
 	}
 
 	b.TeleBot.Use(logger.TelebotMiddleware())

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -346,8 +346,6 @@ func broadcastTaskResult(b *tb.Bot, chatID int64, text string) {
 	if chatID != 0 {
 		if err := sendLong(b, tb.ChatID(chatID), text); err != nil {
 			DefaultErrorHandler.HandleTelegramError(err, chatID)
-		} else {
-			logger.L.Debug("telegram sent", "chat_id", chatID)
 		}
 		return
 	}
@@ -362,8 +360,6 @@ func broadcastTaskResult(b *tb.Bot, chatID int64, text string) {
 	for _, id := range ids {
 		if err := sendLong(b, tb.ChatID(id), text); err != nil {
 			DefaultErrorHandler.HandleTelegramError(err, id)
-		} else {
-			logger.L.Debug("telegram sent", "chat_id", id)
 		}
 	}
 }
@@ -390,12 +386,9 @@ func scheduleTask(s *gocron.Scheduler, task Task, job func()) error {
 		return err
 	}
 
-	// Register event listeners for monitoring
+	// Register event listeners for monitoring (debug logging removed to prevent spam)
 	j.RegisterEventListeners(
-		gocron.BeforeJobRuns(func(jobName string) { logger.L.Debug("job start", "job", task.Name) }),
-		gocron.AfterJobRuns(func(jobName string) { logger.L.Debug("job end", "job", task.Name) }),
 		gocron.WhenJobReturnsError(func(jobName string, err error) { logger.L.Error("job error", "job", task.Name, "err", err) }),
-		gocron.WhenJobReturnsNoError(func(jobName string) { logger.L.Debug("job success", "job", task.Name) }),
 	)
 	j.Tag(task.Name)
 

--- a/internal/bot/openai_helper.go
+++ b/internal/bot/openai_helper.go
@@ -213,7 +213,7 @@ func StreamChatCompletion(ctx context.Context, client StreamCompleter, msgs []op
 
 	stream, err := client.CreateChatCompletionStream(ctx, req)
 	if err != nil {
-		logger.L.Debug("openai stream error", "err", err)
+		// OpenAI stream error logging removed
 		close(outCh)
 		return outCh, err
 	}
@@ -331,10 +331,10 @@ func ChatCompletion(ctx context.Context, client ChatCompleter, msgs []openai.Cha
 
 	resp, err := client.CreateChatCompletion(ctx, req)
 	if err != nil {
-		logger.L.Debug("openai error", "err", err)
+		// OpenAI error logging removed
 		return "", err
 	}
-	logger.L.Debug("openai response", "choices", len(resp.Choices))
+	// OpenAI response debug logging removed
 	if len(resp.Choices) == 0 {
 		return "", nil
 	}
@@ -380,7 +380,7 @@ func ChatCompletion(ctx context.Context, client ChatCompleter, msgs []openai.Cha
 		}
 	}
 	out := strings.TrimSpace(msg.Content)
-	logger.L.Debug("openai result", "length", len(out), "preview", logger.Truncate(out, 200))
+	// OpenAI result debug logging removed
 	if len(out) == 0 {
 		logger.L.Warn("empty openai response", "msg_content", msg.Content, "msg_role", msg.Role)
 	}

--- a/internal/bot/openai_search.go
+++ b/internal/bot/openai_search.go
@@ -2,8 +2,6 @@ package bot
 
 import (
 	"context"
-
-	"telegram-reminder/internal/logger"
 )
 
 // OpenAISearch performs a web search using the OpenAI responses API and returns

--- a/internal/bot/openai_search.go
+++ b/internal/bot/openai_search.go
@@ -9,16 +9,14 @@ import (
 // OpenAISearch performs a web search using the OpenAI responses API and returns
 // the result formatted for Telegram HTML.
 func OpenAISearch(query string) (string, error) {
-	logger.L.Debug("openai search", "query", query)
+	// Debug logging removed to prevent Telegram spam
 	ctx, cancel := context.WithTimeout(context.Background(), OpenAITimeout)
 	defer cancel()
 
 	out, err := defaultWebSearch(ctx, query)
 	if err != nil {
-		logger.L.Debug("openai search error", "err", err)
 		return "", err
 	}
 	out = markdownToTelegramHTML(out)
-	logger.L.Debug("openai search result", "bytes", len(out))
 	return out, nil
 }

--- a/internal/logger/http.go
+++ b/internal/logger/http.go
@@ -8,18 +8,12 @@ import (
 type loggingTransport struct{ base http.RoundTripper }
 
 func (t loggingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	start := time.Now()
-	if req.Body != nil && req.ContentLength > 0 {
-		L.Debug("http request", "method", req.Method, "url", req.URL.String(), "bytes", req.ContentLength)
-	} else {
-		L.Debug("http request", "method", req.Method, "url", req.URL.String())
-	}
+	// HTTP request/response debug logging removed to prevent Telegram spam
 	resp, err := t.base.RoundTrip(req)
 	if err != nil {
 		L.Error("http error", "method", req.Method, "url", req.URL.String(), "err", err)
 		return nil, err
 	}
-	L.Debug("http response", "method", req.Method, "url", req.URL.String(), "status", resp.StatusCode, "duration", time.Since(start))
 	return resp, nil
 }
 

--- a/internal/logger/manager.go
+++ b/internal/logger/manager.go
@@ -108,9 +108,7 @@ func (lm *LoggerManager) SetModuleLevel(module string, level slog.Level) {
 	lm.config.ModuleLevels[module] = level
 	
 	// Recreate logger with new level
-	if _, exists := lm.loggers[module]; exists {
-		delete(lm.loggers, module)
-	}
+	delete(lm.loggers, module)
 }
 
 // EnableTelegramLogging enables telegram logging for critical events

--- a/internal/logger/telebot_logger.go
+++ b/internal/logger/telebot_logger.go
@@ -4,18 +4,10 @@ import (
 	tb "gopkg.in/telebot.v3"
 )
 
-// TelebotMiddleware logs every incoming update at debug level and reports handler errors.
+// TelebotMiddleware reports handler errors only, without debug spam.
 func TelebotMiddleware() tb.MiddlewareFunc {
 	return func(next tb.HandlerFunc) tb.HandlerFunc {
 		return func(c tb.Context) error {
-			if m := c.Message(); m != nil {
-				L.Debug("update message", "chat", m.Chat.ID, "text", m.Text)
-			} else if cb := c.Callback(); cb != nil {
-				L.Debug("update callback", "chat", cb.Message.Chat.ID, "data", cb.Data)
-			} else {
-				up := c.Update()
-				L.Debug("update", "id", up.ID)
-			}
 			err := next(c)
 			if err != nil {
 				L.Error("handler error", "err", err)

--- a/internal/services/ai_adapter.go
+++ b/internal/services/ai_adapter.go
@@ -82,11 +82,7 @@ func (a *OpenAIAdapter) chatCompletion(ctx context.Context, msgs []openai.ChatCo
 
 	msg := resp.Choices[0].Message
 
-	// Handle tool calls for web search
-	if config.EnableWebSearch && len(msg.ToolCalls) > 0 {
-		// This would integrate with the existing web search functionality
-		// For now, just return the content
-	}
+	// Handle tool calls for web search - integration would go here if needed
 
 	out := strings.TrimSpace(msg.Content)
 	// OpenAI result debug logging removed
@@ -160,11 +156,3 @@ func getWebSearchTool() openai.Tool {
 	}
 }
 
-// truncateString truncates a string to maxLen characters
-func truncateString(s string, maxLen int) string {
-	r := []rune(s)
-	if len(r) <= maxLen {
-		return s
-	}
-	return string(r[:maxLen]) + "..."
-}

--- a/internal/services/ai_adapter.go
+++ b/internal/services/ai_adapter.go
@@ -86,11 +86,10 @@ func (a *OpenAIAdapter) chatCompletion(ctx context.Context, msgs []openai.ChatCo
 	if config.EnableWebSearch && len(msg.ToolCalls) > 0 {
 		// This would integrate with the existing web search functionality
 		// For now, just return the content
-		logger.L.Debug("tool calls detected", "count", len(msg.ToolCalls))
 	}
 
 	out := strings.TrimSpace(msg.Content)
-	logger.L.Debug("openai result", "length", len(out), "preview", truncateString(out, 200))
+	// OpenAI result debug logging removed
 
 	if len(out) == 0 {
 		logger.L.Warn("empty openai response", "msg_content", msg.Content, "msg_role", msg.Role)


### PR DESCRIPTION
## Summary
- Fix Telegram logging level from DEBUG to ERROR to prevent spam
- Remove debug logs from HTTP transport, scheduler middleware, and OpenAI functions
- Fix golangci-lint warning about unnecessary guard around delete()

## Problem
The bot was sending ALL debug messages to Telegram chat when LOG_CHAT_ID was configured, 
including HTTP requests, job lifecycle events, and OpenAI API calls. This created spam.

## Solution
- Change Telegram logging level to ERROR only for critical issues
- Remove debug logging from key components that were spamming
- Keep error logging for actual problems

## Test plan
- [x] Telegram logging level changed to ERROR
- [x] Debug logs removed from HTTP, scheduler, OpenAI functions
- [x] Only critical errors will be sent to LOG_CHAT_ID now
- [x] Golangci-lint warning fixed

🤖 Generated with [Claude Code](https://claude.ai/code)